### PR TITLE
Return type annotation + Vector

### DIFF
--- a/io/src/main/scala/sbt/internal/io/Alternative.scala
+++ b/io/src/main/scala/sbt/internal/io/Alternative.scala
@@ -4,10 +4,10 @@ import sbt.io.Alternative
 
 private[sbt] object Alternatives {
   import sbt.io.syntax._
-  final def alternatives[A, B](alts: Seq[A => Option[B]]): A => Option[B] =
+  final def alternatives[A, B](alts: Vector[A => Option[B]]): A => Option[B] =
     alts match {
-      case Seq(f, fs @ _*) => alternative(f) | alternatives(fs)
-      case Seq()           => a => None
+      case Vector(f, fs @ _*) => alternative(f) | alternatives(fs.toVector)
+      case Vector()           => a => None
     }
 
   implicit def alternative[A, B](f: A => Option[B]): Alternative[A, B] =

--- a/io/src/main/scala/sbt/internal/io/DeferredWriter.scala
+++ b/io/src/main/scala/sbt/internal/io/DeferredWriter.scala
@@ -7,21 +7,21 @@ private[sbt] final class DeferredWriter(make: => Writer) extends Writer {
   private[this] var opened = false
   private[this] var delegate0: Writer = _
   private[this] def delegate: Writer = synchronized {
-    if (delegate0 eq null) {
+    if (Option(delegate0).isEmpty) {
       delegate0 = make
       opened = true
     }
     delegate0
   }
-  override def close() = synchronized {
+  override def close(): Unit = synchronized {
     if (opened) delegate0.close()
   }
 
   override def append(c: Char): Writer = delegate.append(c)
   override def append(csq: CharSequence): Writer = delegate.append(csq)
   override def append(csq: CharSequence, start: Int, end: Int): Writer = delegate.append(csq, start, end)
-  override def flush() = delegate.flush()
-  override def write(cbuf: Array[Char]) = delegate.write(cbuf)
+  override def flush(): Unit = delegate.flush()
+  override def write(cbuf: Array[Char]): Unit = delegate.write(cbuf)
   override def write(cbuf: Array[Char], off: Int, len: Int): Unit = delegate.write(cbuf, off, len)
   override def write(c: Int): Unit = delegate.write(c)
   override def write(s: String): Unit = delegate.write(s)

--- a/io/src/main/scala/sbt/internal/io/ErrorHandling.scala
+++ b/io/src/main/scala/sbt/internal/io/ErrorHandling.scala
@@ -6,7 +6,7 @@ package sbt.internal.io
 import java.io.IOException
 
 private[sbt] object ErrorHandling {
-  def translate[T](msg: => String)(f: => T) =
+  def translate[T](msg: => String)(f: => T): T =
     try { f }
     catch {
       case e: IOException => throw new TranslatedIOException(msg + e.toString, e)
@@ -28,11 +28,11 @@ private[sbt] object ErrorHandling {
   def reducedToString(e: Throwable): String =
     if (e.getClass == classOf[RuntimeException]) {
       val msg = e.getMessage
-      if (msg == null || msg.isEmpty) e.toString else msg
-    } else
-      e.toString
+      if (Option(msg).isEmpty || msg.isEmpty) e.toString
+      else msg
+    } else e.toString
 }
 private[sbt] sealed class TranslatedException private[sbt] (msg: String, cause: Throwable) extends RuntimeException(msg, cause) {
-  override def toString = msg
+  override def toString: String = msg
 }
 private[sbt] final class TranslatedIOException private[sbt] (msg: String, cause: IOException) extends TranslatedException(msg, cause)

--- a/io/src/main/scala/sbt/internal/io/Resources.scala
+++ b/io/src/main/scala/sbt/internal/io/Resources.scala
@@ -8,11 +8,11 @@ import sbt.io.IO._
 import Resources.error
 
 private[sbt] object Resources {
-  def apply(basePath: String) =
+  def apply(basePath: String): Resources =
     {
       require(basePath.startsWith("/"))
       val resource = getClass.getResource(basePath)
-      if (resource == null)
+      if (Option(resource).isEmpty)
         error("Resource base directory '" + basePath + "' not on classpath.")
       else {
         val file = toFile(resource)
@@ -22,7 +22,7 @@ private[sbt] object Resources {
           error("Resource base directory '" + basePath + "' does not exist.")
       }
     }
-  def error(msg: String) = throw new ResourcesException(msg)
+  def error(msg: String): Nothing = throw new ResourcesException(msg)
   private val LoadErrorPrefix = "Error loading initial project: "
 }
 private[sbt] final class ResourcesException(msg: String) extends Exception(msg)

--- a/io/src/main/scala/sbt/internal/io/SourceModificationWatch.scala
+++ b/io/src/main/scala/sbt/internal/io/SourceModificationWatch.scala
@@ -43,5 +43,5 @@ private[sbt] final class WatchState(val lastCallbackCallTime: Long, val previous
 }
 
 private[sbt] object WatchState {
-  def empty = new WatchState(0L, Set.empty[String], false, 0)
+  def empty: WatchState = new WatchState(0L, Set.empty[String], false, 0)
 }

--- a/io/src/main/scala/sbt/internal/io/SourceModificationWatch.scala
+++ b/io/src/main/scala/sbt/internal/io/SourceModificationWatch.scala
@@ -11,7 +11,7 @@ private[sbt] object SourceModificationWatch {
     {
       import state._
 
-      val sourceFiles: Iterable[java.io.File] = sourcesFinder.get
+      val sourceFiles: Vector[java.io.File] = sourcesFinder.get
       val sourceFilesPath: Set[String] = sourceFiles.map(_.getCanonicalPath)(collection.breakOut)
       val lastModifiedTime =
         (0L /: sourceFiles) { (acc, file) => math.max(acc, file.lastModified) }

--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -322,7 +322,10 @@ object IO {
     {
       val file = File.createTempFile(prefix, postfix)
       try { action(file) }
-      finally { file.delete(); () }
+      finally {
+        file.delete()
+        ()
+      }
     }
 
   private[sbt] def jars(dir: File): Iterable[File] = listFiles(dir, GlobFilter("*.jar"))
@@ -571,10 +574,11 @@ object IO {
    * If `preserveLastModified` is `true`, the last modified times are transferred as well.
    * Any parent directories that do not exist are created.
    */
-  def copyDirectory(source: File, target: File, overwrite: Boolean = false, preserveLastModified: Boolean = false): Unit = {
-    copy(PathFinder(source).allPaths pair Path.rebase(source, target), overwrite, preserveLastModified)
-    ()
-  }
+  def copyDirectory(source: File, target: File, overwrite: Boolean = false, preserveLastModified: Boolean = false): Unit =
+    {
+      copy(PathFinder(source).allPaths pair Path.rebase(source, target), overwrite, preserveLastModified)
+      ()
+    }
 
   /**
    * Copies the contents of `sourceFile` to the location of `targetFile`, overwriting any existing content.

--- a/io/src/main/scala/sbt/io/NameFilter.scala
+++ b/io/src/main/scala/sbt/io/NameFilter.scala
@@ -45,52 +45,52 @@ trait NameFilter extends FileFilter {
 
 /** A [[FileFilter]] that selects files that are hidden according to `java.io.File.isHidden` or if they start with a dot (`.`). */
 object HiddenFileFilter extends FileFilter {
-  def accept(file: File) = file.isHidden && file.getName != "."
+  def accept(file: File): Boolean = file.isHidden && file.getName != "."
 }
 
 /** A [[FileFilter]] that selects files that exist according to `java.io.File.exists`. */
 object ExistsFileFilter extends FileFilter {
-  def accept(file: File) = file.exists
+  def accept(file: File): Boolean = file.exists
 }
 
 /** A [[FileFilter]] that selects files that are a directory according to `java.io.File.isDirectory`. */
 object DirectoryFilter extends FileFilter {
-  def accept(file: File) = file.isDirectory
+  def accept(file: File): Boolean = file.isDirectory
 }
 
 /** A [[FileFilter]] that selects files according the predicate `acceptFunction`. */
 final class SimpleFileFilter(val acceptFunction: File => Boolean) extends FileFilter {
-  def accept(file: File) = acceptFunction(file)
+  def accept(file: File): Boolean = acceptFunction(file)
 }
 
 /** A [[NameFilter]] that accepts a name if it is exactly equal to `matchName`. */
 final class ExactFilter(val matchName: String) extends NameFilter {
-  def accept(name: String) = matchName == name
+  def accept(name: String): Boolean = matchName == name
 }
 
 /** A [[NameFilter]] that accepts a name if the predicate `acceptFunction` accepts it. */
 final class SimpleFilter(val acceptFunction: String => Boolean) extends NameFilter {
-  def accept(name: String) = acceptFunction(name)
+  def accept(name: String): Boolean = acceptFunction(name)
 }
 
 /** A [[NameFilter]] that accepts a name if it matches the regular expression defined by `pattern`. */
 final class PatternFilter(val pattern: Pattern) extends NameFilter {
-  def accept(name: String) = pattern.matcher(name).matches
+  def accept(name: String): Boolean = pattern.matcher(name).matches
 }
 
 /** A [[NameFilter]] that accepts all names. That is, `accept` always returns `true`. */
 object AllPassFilter extends NameFilter {
-  def accept(name: String) = true
+  def accept(name: String): Boolean = true
 }
 
 /** A [[NameFilter]] that accepts nothing.  That is, `accept` always returns `false`. */
 object NothingFilter extends NameFilter {
-  def accept(name: String) = false
+  def accept(name: String): Boolean = false
 }
 
 object NameFilter {
   implicit def fnToNameFilter(f: String => Boolean): NameFilter = new NameFilter {
-    def accept(name: String) = f(name)
+    def accept(name: String): Boolean = f(name)
   }
 }
 object FileFilter {

--- a/io/src/main/scala/sbt/io/Path.scala
+++ b/io/src/main/scala/sbt/io/Path.scala
@@ -74,10 +74,16 @@ object Path extends Mapper {
 
 object PathFinder {
   /** A <code>PathFinder</code> that always produces the empty set of <code>Path</code>s.*/
-  val empty = new PathFinder { private[sbt] def addTo(fileSet: mutable.Set[File]) = () }
+  val empty = new PathFinder {
+    private[sbt] def addTo(fileSet: mutable.Set[File]): Unit = ()
+  }
   def strict(files: Traversable[File]): PathFinder = apply(files)
   def apply(files: => Traversable[File]): PathFinder = new PathFinder {
-    private[sbt] def addTo(fileSet: mutable.Set[File]) = { fileSet ++= files; () }
+    private[sbt] def addTo(fileSet: mutable.Set[File]): Unit =
+      {
+        fileSet ++= files
+        ()
+      }
   }
   def apply(file: File): PathFinder = new SingleFile(file)
 }
@@ -188,7 +194,11 @@ sealed abstract class PathFinder {
   override def toString: String = get.mkString("\n   ", "\n   ", "")
 }
 private class SingleFile(asFile: File) extends PathFinder {
-  private[sbt] def addTo(fileSet: mutable.Set[File]): Unit = if (asFile.exists) { fileSet += asFile; () }
+  private[sbt] def addTo(fileSet: mutable.Set[File]): Unit =
+    if (asFile.exists) {
+      fileSet += asFile
+      ()
+    }
 }
 private abstract class FilterFiles extends PathFinder with FileFilter {
   def parent: PathFinder
@@ -225,7 +235,7 @@ private class Paths(a: PathFinder, b: PathFinder) extends PathFinder {
   }
 }
 private class ExcludeFiles(include: PathFinder, exclude: PathFinder) extends PathFinder {
-  private[sbt] def addTo(pathSet: mutable.Set[File]) = {
+  private[sbt] def addTo(pathSet: mutable.Set[File]): Unit = {
     val includeSet = new mutable.LinkedHashSet[File]
     include.addTo(includeSet)
 

--- a/io/src/main/scala/sbt/io/Path.scala
+++ b/io/src/main/scala/sbt/io/Path.scala
@@ -13,27 +13,27 @@ import scala.language.implicitConversions
 final class RichFile(val asFile: File) {
   def /(component: String): File = if (component == ".") asFile else new File(asFile, component)
   /** True if and only if the wrapped file exists.*/
-  def exists = asFile.exists
+  def exists: Boolean = asFile.exists
   /** True if and only if the wrapped file is a directory.*/
-  def isDirectory = asFile.isDirectory
+  def isDirectory: Boolean = asFile.isDirectory
   /** The last modified time of the wrapped file.*/
-  def lastModified = asFile.lastModified
+  def lastModified: Long = asFile.lastModified
   /* True if and only if the wrapped file `asFile` exists and the file 'other'
-	* does not exist or was modified before the `asFile`.*/
+   * does not exist or was modified before the `asFile`.*/
   def newerThan(other: File): Boolean = Path.newerThan(asFile, other)
   /* True if and only if the wrapped file `asFile` does not exist or the file `other`
-	* exists and was modified after `asFile`.*/
+   * exists and was modified after `asFile`.*/
   def olderThan(other: File): Boolean = Path.newerThan(other, asFile)
   /** The wrapped file converted to a <code>URL</code>.*/
-  def asURL = asFile.toURI.toURL
+  def asURL: URL = asFile.toURI.toURL
   def absolutePath: String = asFile.getAbsolutePath
 
   /** The last component of this path.*/
-  def name = asFile.getName
+  def name: String = asFile.getName
   /** The extension part of the name of this path.  This is the part of the name after the last period, or the empty string if there is no period.*/
-  def ext = baseAndExt._2
+  def ext: String = baseAndExt._2
   /** The base of the name of this path.  This is the part of the name before the last period, or the full name if there is no period.*/
-  def base = baseAndExt._1
+  def base: String = baseAndExt._1
   def baseAndExt: (String, String) =
     {
       val nme = name
@@ -151,7 +151,8 @@ sealed abstract class PathFinder {
     (this ** include) --- (this ** intermediateExclude ** include)
 
   /**
-   * Evaluates this finder and converts the results to a `Seq` of distinct `File`s.  The files returned by this method will reflect the underlying filesystem at the
+   * Evaluates this finder and converts the results to a `Seq` of distinct `File`s.
+   * The files returned by this method will reflect the underlying filesystem at the
    * time of calling.  If the filesystem changes, two calls to this method might be different.
    */
   final def get: Seq[File] =
@@ -178,10 +179,13 @@ sealed abstract class PathFinder {
    */
   def distinct: PathFinder = PathFinder { get.map(p => (p.asFile.getName, p)).toMap.values }
 
-  /** Constructs a string by evaluating this finder, converting the resulting Paths to absolute path strings, and joining them with the platform path separator.*/
-  final def absString = Path.makeString(get)
+  /**
+   * Constructs a string by evaluating this finder, converting the resulting Paths to absolute path strings,
+   * and joining them with the platform path separator.
+   */
+  final def absString: String = Path.makeString(get)
   /** Constructs a debugging string for this finder by evaluating it and separating paths by newlines.*/
-  override def toString = get.mkString("\n   ", "\n   ", "")
+  override def toString: String = get.mkString("\n   ", "\n   ", "")
 }
 private class SingleFile(asFile: File) extends PathFinder {
   private[sbt] def addTo(fileSet: mutable.Set[File]): Unit = if (asFile.exists) { fileSet += asFile; () }
@@ -189,7 +193,7 @@ private class SingleFile(asFile: File) extends PathFinder {
 private abstract class FilterFiles extends PathFinder with FileFilter {
   def parent: PathFinder
   def filter: FileFilter
-  final def accept(file: File) = filter.accept(file)
+  final def accept(file: File): Boolean = filter.accept(file)
 
   protected def handleFile(file: File, fileSet: mutable.Set[File]): Unit =
     for (matchedFile <- wrapNull(file.listFiles(this)))

--- a/io/src/main/scala/sbt/io/PathMapper.scala
+++ b/io/src/main/scala/sbt/io/PathMapper.scala
@@ -20,7 +20,7 @@ abstract class Mapper {
    */
   def relativeTo(base: File): PathMap = IO.relativize(base, _)
 
-  def relativeTo(bases: Iterable[File], zero: PathMap = transparent): PathMap = fold(zero, bases)(relativeTo)
+  def relativeTo(bases: Vector[File], zero: PathMap = transparent): PathMap = fold(zero, bases)(relativeTo)
 
   /**
    * A path mapper that pairs a descendent of `oldBase` with `newBase` prepended to the path relative to `oldBase`.
@@ -73,7 +73,7 @@ abstract class Mapper {
    */
   def resolve(newDirectory: File): FileMap = file => if (file.isAbsolute) None else Some(new File(newDirectory, file.getPath))
 
-  def rebase(oldBases: Iterable[File], newBase: File, zero: FileMap = transparent): FileMap =
+  def rebase(oldBases: Vector[File], newBase: File, zero: FileMap = transparent): FileMap =
     fold(zero, oldBases)(old => rebase(old, newBase))
 
   /**
@@ -100,16 +100,16 @@ abstract class Mapper {
    * Selects all descendants of `base` directory and maps them to a path relative to `base`.
    * `base` itself is not included.
    */
-  def allSubpaths(base: File): Traversable[(File, String)] =
+  def allSubpaths(base: File): Vector[(File, String)] =
     selectSubpaths(base, AllPassFilter)
 
   /**
    * Selects descendants of `base` directory matching `filter` and maps them to a path relative to `base`.
    * `base` itself is not included.
    */
-  def selectSubpaths(base: File, filter: FileFilter): Traversable[(File, String)] =
+  def selectSubpaths(base: File, filter: FileFilter): Vector[(File, String)] =
     (PathFinder(base) ** filter --- PathFinder(base)) pair (relativeTo(base) | flat)
 
-  private[this] def fold[A, B, T](zero: A => Option[B], in: Iterable[T])(f: T => A => Option[B]): A => Option[B] =
+  private[this] def fold[A, B, T](zero: A => Option[B], in: Vector[T])(f: T => A => Option[B]): A => Option[B] =
     (zero /: in)((mapper, base) => f(base) | mapper)
 }

--- a/io/src/main/scala/sbt/io/PathMapper.scala
+++ b/io/src/main/scala/sbt/io/PathMapper.scala
@@ -57,7 +57,9 @@ abstract class Mapper {
   /** A mapper that ignores all inputs.*/
   def transparent: Any => Option[Nothing] = _ => None
 
-  def normalizeBase(base: String) = if (!base.isEmpty && !base.endsWith("/")) base + "/" else base
+  def normalizeBase(base: String): String =
+    if (!base.isEmpty && !base.endsWith("/")) base + "/"
+    else base
 
   /**
    * Pairs a File with the absolute File obtained by calling `getAbsoluteFile`.
@@ -75,7 +77,8 @@ abstract class Mapper {
     fold(zero, oldBases)(old => rebase(old, newBase))
 
   /**
-   * Produces a File mapper that pairs a descendant of `oldBase` with a file in `newBase` that preserving the relative path of the original file against `oldBase`.
+   * Produces a File mapper that pairs a descendant of `oldBase` with a file in `newBase`
+   * that preserving the relative path of the original file against `oldBase`.
    * For example, if `oldBase` is `/old/x/` and `newBase` is `/new/a/`, `/old/x/y/z.txt` gets paired with `/new/a/y/z.txt`.
    */
   def rebase(oldBase: File, newBase: File): FileMap =

--- a/io/src/test/scala/StashSpec.scala
+++ b/io/src/test/scala/StashSpec.scala
@@ -11,7 +11,7 @@ import Function.tupled
 
 class StashSpec extends FlatSpec with Matchers {
   "stash" should "handle empty files" in {
-    stash(Set()) {}
+    stash(Vector()) {}
     assert(true)
   }
 
@@ -42,7 +42,7 @@ class StashSpec extends FlatSpec with Matchers {
   }
   def stash0(seq: Seq[File], post: => Unit): Boolean =
     try {
-      stash(Set() ++ seq) {
+      stash(Vector() ++ seq) {
         noneExist(seq)
         post
       }

--- a/project/house.sbt
+++ b/project/house.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-sbt" % "sbt-houserules" % "0.2.1")
+addSbtPlugin("org.scala-sbt" % "sbt-houserules" % "0.2.2")

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -1,0 +1,117 @@
+<scalastyle>
+ <name>Scalastyle standard configuration</name>
+ <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="false">
+  <parameters>
+   <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="false">
+  <parameters>
+   <parameter name="header"><![CDATA[// Copyright (C) 2011-2012 the original author or authors.
+// See the LICENCE.txt file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxLineLength"><![CDATA[160]]></parameter>
+   <parameter name="tabSize"><![CDATA[4]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+  <parameters>
+   <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
+  <parameters>
+   <parameter name="maxParameters"><![CDATA[8]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
+  <parameters>
+   <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[println]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+  <parameters>
+   <parameter name="maxTypes"><![CDATA[30]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+  <parameters>
+   <parameter name="maximum"><![CDATA[10]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="false">
+  <parameters>
+   <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
+   <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxLength"><![CDATA[50]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="false">
+  <parameters>
+   <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="false">
+  <parameters>
+   <parameter name="maxMethods"><![CDATA[30]]></parameter>
+  </parameters>
+ </check>
+ <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+</scalastyle>


### PR DESCRIPTION
This annotates all public methods' return types.
Uses `Vector` when possible.

/review @Duhemm, @dwijnand, @jsuereth 
