### PR TITLE
FPORT: Support classes located in runtime jars

### DIFF
--- a/io/src/test/scala/sbt/io/IOSpecification.scala
+++ b/io/src/test/scala/sbt/io/IOSpecification.scala
@@ -18,6 +18,7 @@ object IOSpecification extends Properties("IO") {
     Gen.oneOf(
       this.getClass,
       classOf[java.lang.Integer],
+      classOf[java.util.AbstractMap.SimpleEntry[String, String]],
       classOf[String],
       classOf[Thread],
       classOf[Properties]


### PR DESCRIPTION
Forward port of sbt/sbt#2268 and sbt/sbt#2342. Also sbt/sbt#2214 and #13.