### PR TITLE
Call getCanonicalPath instead of getAbsolutePath

### DIFF
--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -538,7 +538,7 @@ object IO {
    */
   def relativize(base: File, file: File): Option[String] =
     {
-      val pathString = file.getAbsolutePath
+      val pathString = file.getCanonicalPath
       baseFileString(base) flatMap
         {
           baseString =>
@@ -553,7 +553,7 @@ object IO {
   private def baseFileString(baseFile: File): Option[String] =
     {
       if (baseFile.isDirectory) {
-        val cp = baseFile.getAbsolutePath
+        val cp = baseFile.getCanonicalPath
         assert(cp.length > 0)
         val normalized = if (cp.charAt(cp.length - 1) == File.separatorChar) cp else cp + File.separatorChar
         Some(normalized)

--- a/io/src/test/scala/sbt/io/IOSpec.scala
+++ b/io/src/test/scala/sbt/io/IOSpec.scala
@@ -1,0 +1,26 @@
+package sbt.io
+
+import java.io.File
+import java.nio.file.Files
+
+import org.scalatest.{ FlatSpec, Matchers }
+
+/**
+ * Created by Lloyd on 4/14/16.
+ *
+ * Copyright 2016
+ */
+class IOSpec extends FlatSpec with Matchers {
+
+  it should "relativize" in {
+    val tempDir = Files.createTempDirectory("io-relativize")
+    val tempFile = Files.createTempFile(tempDir, "meh", "file")
+    val tempDirInDir = Files.createTempDirectory(tempDir, "inside-dir")
+
+    val dirFromDirInDir = new File(tempDirInDir.toFile, "..")
+
+    IO.relativize(tempDir.toFile, tempFile.toFile).isDefined shouldBe true
+    IO.relativize(dirFromDirInDir, tempFile.toFile).isDefined shouldBe true
+  }
+
+}


### PR DESCRIPTION
Allows us to `relativize` when basePath is provided as a relative path (see [this test](https://github.com/sbt/io/compare/master...lloydmeta:feature/relativize-to-getCanonical?expand=1#diff-5551e06aa83dd61e90ee4f4265a098e6R23))
