### PR TITLE
Make IO.relativize relativize less aggressively

### DIFF
--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -534,8 +534,10 @@ object IO {
   def relativize(base: File, file: File): Option[String] = {
     val basePath = base.toPath
     val filePath = file.toPath
-    val relativePath = catching(classOf[IllegalArgumentException]) opt (basePath relativize filePath)
-    relativePath map (_.toString)
+    if (filePath.normalize() startsWith basePath.normalize()) {
+      val relativePath = catching(classOf[IllegalArgumentException]) opt (basePath relativize filePath)
+      relativePath map (_.toString)
+    } else None
   }
 
   /**

--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -403,15 +403,13 @@ object IO {
   /** Returns the children of directory `dir` in a non-null array.*/
   def listFiles(dir: File): Array[File] = wrapNull(dir.listFiles())
 
-  private[sbt] def wrapNull(a: Array[File]) =
-    if (a == null)
-      new Array[File](0)
-    else
-      a
+  private[sbt] def wrapNull(a: Array[File]) = if (a == null) new Array[File](0) else a
 
   /**
    * Creates a jar file.
-   * @param sources The files to include in the jar file paired with the entry name in the jar.  Only the pairs explicitly listed are included.
+   *
+   * @param sources The files to include in the jar file paired with the entry name in the jar.
+   *                Only the pairs explicitly listed are included.
    * @param outputJar The file to write the jar to.
    * @param manifest The manifest for the jar.
    */
@@ -420,7 +418,8 @@ object IO {
 
   /**
    * Creates a zip file.
-   * @param sources The files to include in the zip file paired with the entry name in the zip.  Only the pairs explicitly listed are included.
+   * @param sources The files to include in the zip file paired with the entry name in the zip.
+   *                Only the pairs explicitly listed are included.
    * @param outputZip The file to write the zip to.
    */
   def zip(sources: Traversable[(File, String)], outputZip: File): Unit =

--- a/io/src/main/scala/sbt/io/Path.scala
+++ b/io/src/main/scala/sbt/io/Path.scala
@@ -3,41 +3,60 @@
  */
 package sbt.io
 
-import IO.wrapNull
 import java.io.File
 import java.net.URL
 import scala.collection.mutable
+import IO.wrapNull
 
 final class RichFile(val asFile: File) {
   def /(component: String): File = if (component == ".") asFile else new File(asFile, component)
+
   /** True if and only if the wrapped file exists.*/
-  def exists = asFile.exists
+  def exists: Boolean = asFile.exists
+
   /** True if and only if the wrapped file is a directory.*/
-  def isDirectory = asFile.isDirectory
+  def isDirectory: Boolean = asFile.isDirectory
+
   /** The last modified time of the wrapped file.*/
-  def lastModified = asFile.lastModified
-  /* True if and only if the wrapped file `asFile` exists and the file 'other'
-	* does not exist or was modified before the `asFile`.*/
+  def lastModified: Long = asFile.lastModified
+
+  /**
+   * True if and only if the wrapped file `asFile` exists and the file 'other'
+   * does not exist or was modified before the `asFile`.
+   */
   def newerThan(other: File): Boolean = Path.newerThan(asFile, other)
-  /* True if and only if the wrapped file `asFile` does not exist or the file `other`
-	* exists and was modified after `asFile`.*/
+
+  /**
+   * True if and only if the wrapped file `asFile` does not exist or the file `other`
+   * exists and was modified after `asFile`.
+   */
   def olderThan(other: File): Boolean = Path.newerThan(other, asFile)
+
   /** The wrapped file converted to a <code>URL</code>.*/
-  def asURL = asFile.toURI.toURL
+  def asURL: URL = asFile.toURI.toURL
+
   def absolutePath: String = asFile.getAbsolutePath
 
   /** The last component of this path.*/
-  def name = asFile.getName
-  /** The extension part of the name of this path.  This is the part of the name after the last period, or the empty string if there is no period.*/
-  def ext = baseAndExt._2
-  /** The base of the name of this path.  This is the part of the name before the last period, or the full name if there is no period.*/
-  def base = baseAndExt._1
-  def baseAndExt: (String, String) =
-    {
-      val nme = name
-      val dot = nme.lastIndexOf('.')
-      if (dot < 0) (nme, "") else (nme.substring(0, dot), nme.substring(dot + 1))
-    }
+  def name: String = asFile.getName
+
+  def baseAndExt: (String, String) = {
+    val nme = name
+    val dot = nme.lastIndexOf('.')
+    if (dot < 0) (nme, "") else (nme.substring(0, dot), nme.substring(dot + 1))
+  }
+
+  /**
+   * The extension part of the name of this path.
+   * This is the part of the name after the last period, or the empty string if there is no period.
+   */
+  def ext: String = baseAndExt._2
+
+  /**
+   * The base of the name of this path.
+   * This is the part of the name before the last period, or the full name if there is no period.
+   */
+  def base: String = baseAndExt._1
 
   def relativize(sub: File): Option[File] = IO.relativizeFile(asFile, sub)
   def relativeTo(base: File): Option[File] = IO.relativizeFile(base, asFile)
@@ -46,8 +65,6 @@ final class RichFile(val asFile: File) {
   def hashString: String = Hash.toHex(hash)
   def hashStringHalf: String = Hash.halve(hashString)
 }
-import java.io.File
-import File.pathSeparator
 
 object Path extends Mapper {
   def apply(f: File): RichFile = new RichFile(f)
@@ -56,7 +73,7 @@ object Path extends Mapper {
   def userHome: File = fileProperty("user.home")
 
   def absolute(file: File): File = new File(file.toURI.normalize).getAbsoluteFile
-  def makeString(paths: Seq[File]): String = makeString(paths, pathSeparator)
+  def makeString(paths: Seq[File]): String = makeString(paths, File.pathSeparator)
   def makeString(paths: Seq[File], sep: String): String = {
     val separated = paths.map(_.getAbsolutePath)
     separated.find(_ contains sep).foreach(p => sys.error(s"Path '$p' contains separator '$sep'"))
@@ -65,109 +82,118 @@ object Path extends Mapper {
   def newerThan(a: File, b: File): Boolean = a.exists && (!b.exists || a.lastModified > b.lastModified)
 
   /** The separator character of the platform.*/
-  val sep = java.io.File.separatorChar
+  val sep: Char = java.io.File.separatorChar
 
   def toURLs(files: Seq[File]): Array[URL] = files.map(_.toURI.toURL).toArray
 }
 
 object PathFinder {
   /** A <code>PathFinder</code> that always produces the empty set of <code>Path</code>s.*/
-  val empty = new PathFinder { private[sbt] def addTo(fileSet: mutable.Set[File]) = () }
-  def strict(files: Traversable[File]): PathFinder = apply(files)
-  def apply(files: => Traversable[File]): PathFinder = new PathFinder {
-    private[sbt] def addTo(fileSet: mutable.Set[File]) = { fileSet ++= files; () }
-  }
+  val empty: PathFinder = new PathFinder { def addTo(fileSet: mutable.Set[File]) = () }
+
   def apply(file: File): PathFinder = new SingleFile(file)
+
+  def apply(files: => Traversable[File]): PathFinder = new PathFinder {
+    def addTo(fileSet: mutable.Set[File]) = { fileSet ++= files; () }
+  }
+
+  def strict(files: Traversable[File]): PathFinder = apply(files)
 }
 
 /**
- * A path finder constructs a set of paths.  The set is evaluated by a call to the <code>get</code>
- * method.  The set will be different for different calls to <code>get</code> if the underlying filesystem
- * has changed.
+ * A path finder constructs a set of paths.
+ * The set is evaluated by a call to the <code>get</code> method.
+ * The set will be different for different calls to <code>get</code> if the underlying filesystem has changed.
  */
 sealed abstract class PathFinder {
   import Path._
   import syntax._
 
-  /** The union of the paths found by this <code>PathFinder</code> with the paths found by 'paths'.*/
+  /** The union of the paths found by this <code>PathFinder</code> with the paths found by 'paths'. */
   def +++(paths: PathFinder): PathFinder = new Paths(this, paths)
-  /** Excludes all paths from <code>excludePaths</code> from the paths selected by this <code>PathFinder</code>.*/
+
+  /** Excludes all paths from <code>excludePaths</code> from the paths selected by this <code>PathFinder</code>. */
   def ---(excludePaths: PathFinder): PathFinder = new ExcludeFiles(this, excludePaths)
+
   /**
    * Constructs a new finder that selects all paths with a name that matches <code>filter</code> and are
    * descendants of paths selected by this finder.
    */
   def globRecursive(filter: FileFilter): PathFinder = new DescendantOrSelfPathFinder(this, filter)
 
-  /**
-   * Alias of globRecursive.
-   */
+  /** Alias of globRecursive. */
   final def **(filter: FileFilter): PathFinder = globRecursive(filter)
 
   def allPaths: PathFinder = **(AllPassFilter)
 
   /**
-   * Constructs a new finder that selects all paths with a name that matches <code>filter</code> and are
-   * immediate children of paths selected by this finder.
+   * Constructs a new finder that selects all paths with a name that matches <code>filter</code>
+   * and are immediate children of paths selected by this finder.
    */
   def glob(filter: FileFilter): PathFinder = new ChildPathFinder(this, filter)
 
-  /**
-   * Alias of glob
-   */
+  /** Alias of glob */
   final def *(filter: FileFilter): PathFinder = glob(filter)
 
   /**
-   * Constructs a new finder that selects all paths with name <code>literal</code> that are immediate children
-   * of paths selected by this finder.
+   * Constructs a new finder that selects all paths with name <code>literal</code>
+   * that are immediate children of paths selected by this finder.
    */
   def /(literal: String): PathFinder = new ChildPathFinder(this, new ExactFilter(literal))
+
   /**
-   * Constructs a new finder that selects all paths with name <code>literal</code> that are immediate children
-   * of paths selected by this finder.
+   * Constructs a new finder that selects all paths with name <code>literal</code>
+   * that are immediate children of paths selected by this finder.
    */
   final def \(literal: String): PathFinder = this / literal
 
   /**
-   * Applies `mapper` to each path selected by this PathFinder and returns the path paired with the non-empty result.
+   * Applies `mapper` to each path selected by this PathFinder
+   * and returns the path paired with the non-empty result.
    * If the result is empty (None) and `errorIfNone` is true, an exception is thrown.
    * If `errorIfNone` is false, the path is dropped from the returned Traversable.
    */
-  def pair[T](mapper: File => Option[T], errorIfNone: Boolean = true): Seq[(File, T)] =
-    {
-      val apply = if (errorIfNone) mapper | fail else mapper
-      for (file <- get; mapped <- apply(file)) yield (file, mapped)
-    }
+  def pair[T](mapper: File => Option[T], errorIfNone: Boolean = true): Seq[(File, T)] = {
+    val apply = if (errorIfNone) mapper | fail else mapper
+    for (file <- get; mapped <- apply(file)) yield file -> mapped
+  }
 
   /**
-   * Selects all descendant paths with a name that matches <code>include</code> and do not have an intermediate
-   * path with a name that matches <code>intermediateExclude</code>.  Typical usage is:
+   * Selects all descendant paths with a name that matches <code>include</code>
+   * and do not have an intermediate path with a name that matches <code>intermediateExclude</code>.
    *
-   * <code>descendantsExcept("*.jar", ".svn")</code>
+   * Typical usage is <code>descendantsExcept("*.jar", ".svn")</code>
    */
   def descendantsExcept(include: FileFilter, intermediateExclude: FileFilter): PathFinder =
     (this ** include) --- (this ** intermediateExclude ** include)
 
   /**
-   * Evaluates this finder and converts the results to a `Seq` of distinct `File`s.  The files returned by this method will reflect the underlying filesystem at the
-   * time of calling.  If the filesystem changes, two calls to this method might be different.
+   * Evaluates this finder and converts the results to a `Seq` of distinct `File`s.
+   * The files returned by this method will reflect the underlying filesystem at the time of calling.
+   * If the filesystem changes, two calls to this method might be different.
    */
-  final def get: Seq[File] =
-    {
-      import collection.JavaConverters._
-      val pathSet: mutable.Set[File] = (new java.util.LinkedHashSet[File]).asScala
-      addTo(pathSet)
-      pathSet.toSeq
-    }
+  final def get: Seq[File] = {
+    import scala.collection.JavaConverters._
+    val pathSet: mutable.Set[File] = (new java.util.LinkedHashSet[File]).asScala
+    addTo(pathSet)
+    pathSet.toSeq
+  }
 
-  /** Only keeps paths for which `f` returns true.  It is non-strict, so it is not evaluated until the returned finder is evaluated.*/
+  /**
+   * Only keeps paths for which `f` returns true.
+   * It is non-strict, so it is not evaluated until the returned finder is evaluated.
+   */
   final def filter(f: File => Boolean): PathFinder = PathFinder(get filter f)
-  /* Non-strict flatMap: no evaluation occurs until the returned finder is evaluated.*/
+
+  /** Non-strict flatMap: no evaluation occurs until the returned finder is evaluated. */
   final def flatMap(f: File => PathFinder): PathFinder = PathFinder(get.flatMap(p => f(p).get))
-  /** Evaluates this finder and converts the results to an `Array` of `URL`s..*/
+
+  /** Evaluates this finder and converts the results to an `Array` of `URL`s. */
   final def getURLs: Array[URL] = get.toArray.map(_.toURI.toURL)
-  /** Evaluates this finder and converts the results to a distinct sequence of absolute path strings.*/
+
+  /** Evaluates this finder and converts the results to a distinct sequence of absolute path strings. */
   final def getPaths: Seq[String] = get.map(_.absolutePath)
+
   private[sbt] def addTo(fileSet: mutable.Set[File]): Unit
 
   /**
@@ -176,48 +202,59 @@ sealed abstract class PathFinder {
    */
   def distinct: PathFinder = PathFinder { get.map(p => (p.asFile.getName, p)).toMap.values }
 
-  /** Constructs a string by evaluating this finder, converting the resulting Paths to absolute path strings, and joining them with the platform path separator.*/
-  final def absString = Path.makeString(get)
-  /** Constructs a debugging string for this finder by evaluating it and separating paths by newlines.*/
+  /**
+   * Constructs a string by evaluating this finder, converting the resulting Paths to absolute path strings,
+   * and joining them with the platform path separator.
+   */
+  final def absString: String = Path.makeString(get)
+
+  /** Constructs a debugging string for this finder by evaluating it and separating paths by newlines. */
   override def toString = get.mkString("\n   ", "\n   ", "")
 }
+
 private class SingleFile(asFile: File) extends PathFinder {
-  private[sbt] def addTo(fileSet: mutable.Set[File]): Unit = if (asFile.exists) { fileSet += asFile; () }
+  private[sbt] def addTo(fileSet: mutable.Set[File]) = if (asFile.exists) { fileSet += asFile; () }
 }
+
 private abstract class FilterFiles extends PathFinder with FileFilter {
   def parent: PathFinder
   def filter: FileFilter
+
   final def accept(file: File) = filter.accept(file)
 
   protected def handleFile(file: File, fileSet: mutable.Set[File]): Unit =
     for (matchedFile <- wrapNull(file.listFiles(this)))
       fileSet += new File(file, matchedFile.getName)
 }
+
 private class DescendantOrSelfPathFinder(val parent: PathFinder, val filter: FileFilter) extends FilterFiles {
   private[sbt] def addTo(fileSet: mutable.Set[File]) = {
     for (file <- parent.get) {
-      if (accept(file))
-        fileSet += file
+      if (accept(file)) fileSet += file
       handleFileDescendant(file, fileSet)
     }
   }
+
   private def handleFileDescendant(file: File, fileSet: mutable.Set[File]): Unit = {
     handleFile(file, fileSet)
     for (childDirectory <- wrapNull(file listFiles DirectoryFilter))
       handleFileDescendant(new File(file, childDirectory.getName), fileSet)
   }
 }
+
 private class ChildPathFinder(val parent: PathFinder, val filter: FileFilter) extends FilterFiles {
-  private[sbt] def addTo(fileSet: mutable.Set[File]): Unit =
+  private[sbt] def addTo(fileSet: mutable.Set[File]) =
     for (file <- parent.get)
       handleFile(file, fileSet)
 }
+
 private class Paths(a: PathFinder, b: PathFinder) extends PathFinder {
   private[sbt] def addTo(fileSet: mutable.Set[File]) = {
     a.addTo(fileSet)
     b.addTo(fileSet)
   }
 }
+
 private class ExcludeFiles(include: PathFinder, exclude: PathFinder) extends PathFinder {
   private[sbt] def addTo(pathSet: mutable.Set[File]) = {
     val includeSet = new mutable.LinkedHashSet[File]

--- a/io/src/main/scala/sbt/io/PathMapper.scala
+++ b/io/src/main/scala/sbt/io/PathMapper.scala
@@ -25,16 +25,19 @@ abstract class Mapper {
    * A path mapper that pairs a descendent of `oldBase` with `newBase` prepended to the path relative to `oldBase`.
    * For example, if `oldBase = /old/x/` and `newBase = new/a/`, then `/old/x/y/z.txt` gets paired with `new/a/y/z.txt`.
    */
-  def rebase(oldBase: File, newBase: String): PathMap =
-    {
-      val normNewBase = normalizeBase(newBase)
-      (file: File) =>
-        if (file == oldBase)
-          Some(if (normNewBase.isEmpty) "." else normNewBase)
-        else
-          IO.relativize(oldBase, file).map(normNewBase + _)
-    }
-  /** A mapper that throws an exception for any input.  This is useful as the last mapper in a pipeline to ensure every input gets mapped.*/
+  def rebase(oldBase: File, newBase: String): PathMap = {
+    val normNewBase = normalizeBase(newBase)
+    (file: File) =>
+      if (file == oldBase)
+        Some(if (normNewBase.isEmpty) "." else normNewBase)
+      else
+        IO.relativize(oldBase, file).map(normNewBase + _)
+  }
+
+  /**
+   * A mapper that throws an exception for any input.
+   * This is useful as the last mapper in a pipeline to ensure every input gets mapped.
+   */
   def fail: Any => Nothing = f => sys.error("No mapping for " + f)
 
   /** A path mapper that pairs a File with its name.  For example, `/x/y/z.txt` gets paired with `z.txt`.*/
@@ -65,10 +68,12 @@ abstract class Mapper {
   def abs: FileMap = f => Some(f.getAbsoluteFile)
 
   /**
-   * Returns a File mapper that resolves a relative File against `newDirectory` and pairs the original File with the resolved File.
+   * Returns a FileMap that resolves a relative File against `newDirectory`
+   * and pairs the original File with the resolved File.
    * The mapper ignores absolute files.
    */
-  def resolve(newDirectory: File): FileMap = file => if (file.isAbsolute) None else Some(new File(newDirectory, file.getPath))
+  def resolve(newDirectory: File): FileMap =
+    file => if (file.isAbsolute) None else Some(new File(newDirectory, file.getPath))
 
   def rebase(oldBases: Iterable[File], newBase: File, zero: FileMap = transparent): FileMap =
     fold(zero, oldBases)(old => rebase(old, newBase))
@@ -85,7 +90,7 @@ abstract class Mapper {
         IO.relativize(oldBase, file) map (r => new File(newBase, r))
 
   /**
-   * Constructs a File mapper that pairs a file with a file with the same name in `newDirectory`.
+   * Constructs a FileMap that pairs a file with a file with the same name in `newDirectory`.
    * For example, if `newDirectory` is `/a/b`, then `/r/s/t/d.txt` will be paired with `/a/b/d.txt`
    */
   def flat(newDirectory: File): FileMap = file => Some(new File(newDirectory, file.getName))

--- a/io/src/test/scala/sbt/io/IOSpec.scala
+++ b/io/src/test/scala/sbt/io/IOSpec.scala
@@ -6,13 +6,21 @@ import org.scalatest.{ FlatSpec, Matchers }
 
 class IOSpec extends FlatSpec with Matchers {
   it should "relativize" in {
+    // Given:
+    // io-relativize/
+    //     meh.file
+    //     inside-dir/
+    //
+    // and
+    // relativeRootDir referring to io-relativize/inside-dir/../
+
     val rootDir = Files.createTempDirectory("io-relativize")
-    val nestedFile = Files.createTempFile(rootDir, "meh", "file").toFile
-    val nestedDir = Files.createTempDirectory(rootDir, "inside-dir").toFile
+    val nestedFile = Files.createFile(rootDir resolve "meh.file").toFile
+    val nestedDir = Files.createDirectory(rootDir resolve "inside-dir").toFile
 
     val relativeRootDir = new File(nestedDir, "..")
 
-    IO.relativize(rootDir.toFile, nestedFile).isDefined shouldBe true
-    IO.relativize(relativeRootDir, nestedFile).isDefined shouldBe true
+    IO.relativize(rootDir.toFile, nestedFile) shouldBe Some("meh.file")
+    IO.relativize(relativeRootDir, nestedFile) shouldBe Some("../../meh.file")
   }
 }

--- a/io/src/test/scala/sbt/io/PathMapperSpec.scala
+++ b/io/src/test/scala/sbt/io/PathMapperSpec.scala
@@ -1,0 +1,25 @@
+package sbt.io
+
+import org.scalatest._
+
+import Path._, sbt.io.syntax._
+
+class PathMapperSpec extends FlatSpec with Matchers {
+  "PathMapper" should "create copy resource mappings correctly" in {
+    val base = file("/")
+
+    val files = Seq(base / "src" / "main" / "resources" / "scalac-plugin.xml")
+    val dirs = Seq(
+      base / "src" / "main" / "resources",
+      base / "target" / "scala-2.11" / "resource_managed" / "main"
+    )
+    val target = base / "target" / "scala-2.11" / "classes"
+
+    val mappings = (files --- dirs) pair (rebase(dirs, target) | flat(target))
+
+    mappings shouldBe Seq(
+      base / "src" / "main" / "resources" / "scalac-plugin.xml" ->
+        base / "target" / "scala-2.11" / "classes" / "scalac-plugin.xml"
+    )
+  }
+}


### PR DESCRIPTION
Specifically, following the scaladoc of relativize, make sure (first) that "base" is not a parent of "file" before trying to relativize.

Prior to this change invoking

```scala
IO.relativize(
  file("/target/scala-2.11/resource_managed/main"),   // base
  file("/src/main/resources/scalac-plugin.xml")       // file
)
```

returned

```scala
Some("../../../../src/main/resources/scalac-plugin.xml")
```

which is incorrect according to the scaladoc of relativize and broke sbt's copyResources implementation.

Created PathMapperSpec to specify and assert the correct behaviour, and as a regression test.