### PR TITLE
patch a perf bottleneck

### DIFF
--- a/io/src/main/scala/sbt/io/Hash.scala
+++ b/io/src/main/scala/sbt/io/Hash.scala
@@ -5,6 +5,7 @@ package sbt.io
 
 import java.io.{ ByteArrayInputStream, File, InputStream }
 import java.net.{ URI, URL }
+import java.nio.file.Files
 
 object Hash {
   private val BufferSize = 8192
@@ -52,7 +53,7 @@ object Hash {
   def apply(as: Array[Byte]): Array[Byte] = apply(new ByteArrayInputStream(as))
 
   /** Calculates the SHA-1 hash of the given file.*/
-  def apply(file: File): Array[Byte] = Using.fileInputStream(file)(apply)
+  def apply(file: File): Array[Byte] = Files.readAllBytes(file.toPath)
 
   /** Calculates the SHA-1 hash of the given resource.*/
   def apply(url: URL): Array[Byte] = Using.urlInputStream(url)(apply)


### PR DESCRIPTION
I did some analysis that looked the same as https://github.com/sbt/zinc/pull/371 then I came up with this patch.

I've spent the last few hours trying to apply this as a monkey patch, but I can't get it to work, so I have absolutely no idea if it improves anything or not.

*UPDATE* this needs to actually calculate the hash. My point is that using NIO should be a lot faster than `FileFilterStream`, which is using 99% of my CPU in the profile (not the calculation of the hash).