### PR TITLE
Encode POSIX file path to URI using u3 (file:///)

### DIFF
--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -154,8 +154,8 @@ object IO {
         // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=5086147
         // The specific problem here is that `uri` will have a defined authority component for UNC names like //foo/bar/some/path.jar
         // but the File constructor requires URIs with an undefined authority component.
-        if (part startsWith "/") new File(part)
-        else new File("//" + part)
+        if (!(part startsWith "/") && (part contains ":")) new File("//" + part)
+        else new File(part)
     }
   }
 
@@ -1007,7 +1007,7 @@ object IO {
       f.toPath.toUri
     } else {
       // need to use the three argument URI constructor because the single argument version doesn't encode
-      new URI(null, normalizeName(f.getPath), null)
+      new URI(FileScheme, normalizeName(f.getPath), null)
     }
 
   /**

--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -119,6 +119,9 @@ object IO {
   def toFile(url: URL): File =
     try { uriToFile(url.toURI) } catch { case _: URISyntaxException => new File(url.getPath) }
 
+  def toFile(uri: URI): File =
+    try { uriToFile(uri) } catch { case _: URISyntaxException => new File(uri.getPath) }
+
   /** Converts the given URL to a File.  If the URL is for an entry in a jar, the File for the jar is returned. */
   def asFile(url: URL): File = urlAsFile(url) getOrElse sys.error("URL is not a file: " + url)
   def urlAsFile(url: URL): Option[File] =
@@ -1000,8 +1003,12 @@ object IO {
 
   /** Converts the given File to a URI.  If the File is relative, the URI is relative, unlike File.toURI*/
   def toURI(f: File): URI =
-    // need to use the three argument URI constructor because the single argument version doesn't encode
-    if (f.isAbsolute) f.toURI else new URI(null, normalizeName(f.getPath), null)
+    if (f.isAbsolute) {
+      f.toPath.toUri
+    } else {
+      // need to use the three argument URI constructor because the single argument version doesn't encode
+      new URI(null, normalizeName(f.getPath), null)
+    }
 
   /**
    * Resolves `f` against `base`, which must be an absolute directory.

--- a/io/src/test/scala/sbt/io/IOSpec.scala
+++ b/io/src/test/scala/sbt/io/IOSpec.scala
@@ -3,9 +3,10 @@ package sbt.io
 import java.io.File
 import java.nio.file.Files
 import org.scalatest.{ FlatSpec, Matchers }
+import sbt.io.syntax._
 
 class IOSpec extends FlatSpec with Matchers {
-  it should "relativize" in {
+  "IO" should "relativize" in {
     // Given:
     // io-relativize/
     //     meh.file
@@ -33,5 +34,15 @@ class IOSpec extends FlatSpec with Matchers {
     IO.relativize(base, file1) shouldBe Some(".git")
     IO.relativize(base, file2) shouldBe Some(".git")
     IO.relativize(base, file3) shouldBe Some(".git")
+  }
+
+  "toURI" should "make URI" in {
+    val u = IO.toURI(file("/etc/hosts"))
+    assert(u.toString == "file:///etc/hosts")
+  }
+
+  it should "make URI that roundtrips" in {
+    val u = IO.toURI(file("/etc/hosts"))
+    assert(IO.toFile(u) == file("/etc/hosts"))
   }
 }

--- a/io/src/test/scala/sbt/io/IOSpec.scala
+++ b/io/src/test/scala/sbt/io/IOSpec.scala
@@ -41,8 +41,18 @@ class IOSpec extends FlatSpec with Matchers {
     assert(u.toString == "file:///etc/hosts")
   }
 
+  it should "make u0 URI from a relative path" in {
+    val u = IO.toURI(file("src/main/scala"))
+    assert(u.toString == "file:src/main/scala")
+  }
+
   it should "make URI that roundtrips" in {
     val u = IO.toURI(file("/etc/hosts"))
     assert(IO.toFile(u) == file("/etc/hosts"))
+  }
+
+  it should "make u0 URI that roundtrips" in {
+    val u = IO.toURI(file("src/main/scala"))
+    assert(IO.toFile(u) == file("src/main/scala"))
   }
 }


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/3801

Under RFC 8089, published in February 2017, an aboslute POSIX file path can be encoded into URI in two different ways.

First is `file:/etc/hosts` with no authority field. Let's call this u1 notation. u1 is the new, minimal representation, and it's what we have been doing (i.e via `f.toURI`) by accident.

Second is `file:///etc/hosts` with an empty authority field. Let's call this u3 notation. u3 is how traditionally file path were supposed to be represented in RFC 3986 (2005) and Kerwin draft (2013). Due to sbt server, we are going to interface non-JVM systems that might not be up to RFC 8089.

For example, Vim's LSP sends URI using u3 `{"textDocument":{"uri":"file:///Users/foo/work/hellotest/Hello.scala"}})`, and more importantly it also *expects* u3 for the compiler error messages to be notified correctly.

https://github.com/sbt/sbt/issues/3702 reported that Atom also expected u3 notation until https://github.com/atom/atom-languageclient/pull/129 fixed it.

I've confirmed that Vim's LSP plugin issue was resolved with this patch and some changes to use it on sbt/sbt.