### PR TITLE
don't put file: scheme for relative path

### DIFF
--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -140,11 +140,15 @@ object IO {
    * Converts the given file URI to a File.
    */
   private[this] def uriToFile(uri: URI): File = {
-    assert(
-      uri.getScheme == FileScheme,
-      "Expected protocol to be '" + FileScheme + "' in URI " + uri
-    )
     val part = uri.getSchemeSpecificPart
+    // scheme might be omitted for relative URI reference.
+    assert(
+      Option(uri.getScheme) match {
+        case None | Some(FileScheme) => true
+        case _                       => false
+      },
+      s"Expected protocol to be '$FileScheme' or empty in URI $uri"
+    )
     Option(uri.getAuthority) match {
       case None if part startsWith "/" => new File(uri)
       case _                           =>
@@ -1007,7 +1011,7 @@ object IO {
       f.toPath.toUri
     } else {
       // need to use the three argument URI constructor because the single argument version doesn't encode
-      new URI(FileScheme, normalizeName(f.getPath), null)
+      new URI(null, normalizeName(f.getPath), null)
     }
 
   /**

--- a/io/src/test/scala/sbt/io/IOSpec.scala
+++ b/io/src/test/scala/sbt/io/IOSpec.scala
@@ -42,8 +42,8 @@ class IOSpec extends FlatSpec with Matchers {
   }
 
   it should "make u0 URI from a relative path" in {
-    val u = IO.toURI(file("src/main/scala"))
-    assert(u.toString == "file:src/main/scala")
+    val u = IO.toURI(file("src") / "main" / "scala")
+    assert(u.toString == "src/main/scala")
   }
 
   it should "make URI that roundtrips" in {
@@ -52,7 +52,7 @@ class IOSpec extends FlatSpec with Matchers {
   }
 
   it should "make u0 URI that roundtrips" in {
-    val u = IO.toURI(file("src/main/scala"))
-    assert(IO.toFile(u) == file("src/main/scala"))
+    val u = IO.toURI(file("src") / "main" / "scala")
+    assert(IO.toFile(u) == (file("src") / "main" / "scala"))
   }
 }


### PR DESCRIPTION
I messed up in c803193df5b796cda0e85bbd7bf43df594942fcd in #96.

Ref https://github.com/eed3si9n/sjson-new/pull/87

Relative path should NOT have `file:` scheme, according to RFC 3986.