### PR TITLE
Adds `IO.getModifiedTimeOrZero(file)` and `IO.setModifiedTimeOrFalse(file)`

### DIFF
--- a/io/src/main/scala/sbt/internal/io/Milli.scala
+++ b/io/src/main/scala/sbt/internal/io/Milli.scala
@@ -237,22 +237,17 @@ private trait Mac extends Library with Posix[Long] {
                   options: Int): Int
 }
 private object MacMilli extends PosixMilliLong[Mac] {
-  private final val ATTR_BIT_MAP_COUNT: Short = 5
-  private final val ATTR_CMN_MODTIME: Int = 0x00000400
+  private val attr = new Attrlist
+  attr.bitmapcount = 5 // ATTR_BIT_MAP_COUNT
+  attr.commonattr = 0x00000400 // ATTR_CMN_MODTIME
 
   protected def getModifiedTimeNative(filePath: String) = {
-    val attr = new Attrlist
-    attr.bitmapcount = ATTR_BIT_MAP_COUNT
-    attr.commonattr = ATTR_CMN_MODTIME
     val buf = new TimeBuf
     checkedIO(filePath) { libc.getattrlist(filePath, attr, buf, 20 /* buf size */, 0) }
     (buf.tv_sec, buf.tv_nsec)
   }
 
   protected def setModifiedTimeNative(filePath: String, mtimeNative: (Long, Long)): Unit = {
-    val attr = new Attrlist
-    attr.bitmapcount = ATTR_BIT_MAP_COUNT
-    attr.commonattr = ATTR_CMN_MODTIME
     val buf = new Timespec
     val (sec, nsec) = mtimeNative
     buf.tv_sec = sec

--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -1139,7 +1139,7 @@ object IO {
    * @see setModifiedTime
    * @see copyModifiedTime
    */
-  @deprecated
+  @deprecated("This method might be removed in the future, also see getModifiedOrZero()", "1.1.3")
   def getModifiedTime(file: File): Long = Milli.getModifiedTime(file)
 
   /**
@@ -1165,7 +1165,8 @@ object IO {
    * @see getModifiedTime
    * @see copyModifiedTime
    */
-  @deprecated
+  @deprecated("This method might be removed in the future, also see setModifiedTimeOrFalse()",
+              "1.1.3")
   def setModifiedTime(file: File, mtime: Long): Unit = Milli.setModifiedTime(file, mtime)
 
   /**
@@ -1190,7 +1191,7 @@ object IO {
    * @see getModifiedTime
    * @see setModifiedTime
    */
-  @deprecated
+  @deprecated("This method might be removed in the future, also see copyLastModified()", "1.1.3")
   def copyModifiedTime(fromFile: File, toFile: File): Unit =
     Milli.copyModifiedTime(fromFile, toFile)
 

--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -1184,11 +1184,12 @@ object IO {
    *
    * @see getModifiedTime
    */
-  def lastModified(file: File): Long = try {
-    getModifiedTime(file)
-  } catch {
-    case _: FileNotFoundException => 0L
-  }
+  def lastModified(file: File): Long =
+    try {
+      getModifiedTime(file)
+    } catch {
+      case _: FileNotFoundException => 0L
+    }
 
   /**
    * Sets the modification time of the file argument, in milliseconds
@@ -1202,12 +1203,13 @@ object IO {
    *
    * @see setModifiedTime
    */
-  def setLastModified(file: File, mtime: Long): Boolean = try {
-    Milli.setModifiedTime(file, mtime)
-    true
-  } catch {
-    case _: FileNotFoundException => false
-  }
+  def setLastModified(file: File, mtime: Long): Boolean =
+    try {
+      Milli.setModifiedTime(file, mtime)
+      true
+    } catch {
+      case _: FileNotFoundException => false
+    }
 
   /**
    * Transfers the last modified time of `sourceFile` to `targetFile`.
@@ -1220,7 +1222,7 @@ object IO {
    * The method returns true if the target file modification time was
    * successfully changed, false otherwise.
    *
-   * After sbt/io v1.1.1, a new method copyModifiedTime() has been added
+   * Since sbt/io v1.1.2, a new method copyModifiedTime() has been added
    * to sbt.io.IO. That method will throw a FileNotFoundException
    * if any of the two files are missing, or an IOException in case an
    * IO exception occurs, so it may be a preferable choice for new code.

--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -15,7 +15,7 @@ import java.io.{
   OutputStream,
   PrintWriter
 }
-import java.io.{ ObjectInputStream, ObjectStreamClass }
+import java.io.{ ObjectInputStream, ObjectStreamClass, FileNotFoundException }
 import java.net.{ URI, URISyntaxException, URL }
 import java.nio.charset.Charset
 import java.nio.file.FileSystems
@@ -306,7 +306,7 @@ object IO {
             }
           }
           if (preserveLastModified)
-            setModifiedTime(target, entry.getTime)
+            setLastModified(target, entry.getTime)
         } else {
           //log.debug("Ignoring zip entry '" + name + "'")
         }
@@ -543,7 +543,7 @@ object IO {
     def makeFileEntry(file: File, name: String) = {
       //			log.debug("\tAdding " + file + " as " + name + " ...")
       val e = createEntry(name)
-      e setTime getModifiedTime(file)
+      e setTime lastModified(file)
       e
     }
     def addFileEntry(file: File, name: String) = {
@@ -643,7 +643,7 @@ object IO {
       preserveLastModified: Boolean,
       preserveExecutable: Boolean
   )(from: File, to: File): File = {
-    if (overwrite || !to.exists || getModifiedTime(from) > getModifiedTime(to)) {
+    if (overwrite || !to.exists || lastModified(from) > lastModified(to)) {
       if (from.isDirectory)
         createDirectory(to)
       else {
@@ -728,7 +728,7 @@ object IO {
       }
     }
     if (preserveLastModified) {
-      copyModifiedTime(sourceFile, targetFile)
+      copyLastModified(sourceFile, targetFile)
       ()
     }
     if (preserveExecutable) {

--- a/io/src/main/scala/sbt/io/Path.scala
+++ b/io/src/main/scala/sbt/io/Path.scala
@@ -9,7 +9,6 @@ import scala.collection.mutable
 import java.nio.file.attribute._
 import java.nio.file.{ Path => NioPath, LinkOption, FileSystem, Files }
 import scala.collection.JavaConverters._
-import sbt.io.IO
 
 final class RichFile(val asFile: File) extends AnyVal with RichNioPath {
   def /(component: String): File = if (component == ".") asFile else new File(asFile, component)

--- a/io/src/main/scala/sbt/io/Path.scala
+++ b/io/src/main/scala/sbt/io/Path.scala
@@ -9,6 +9,7 @@ import scala.collection.mutable
 import java.nio.file.attribute._
 import java.nio.file.{ Path => NioPath, LinkOption, FileSystem, Files }
 import scala.collection.JavaConverters._
+import sbt.io.IO
 
 final class RichFile(val asFile: File) extends AnyVal with RichNioPath {
   def /(component: String): File = if (component == ".") asFile else new File(asFile, component)
@@ -20,7 +21,7 @@ final class RichFile(val asFile: File) extends AnyVal with RichNioPath {
   def isDirectory: Boolean = asFile.isDirectory
 
   /** The last modified time of the wrapped file.*/
-  def lastModified: Long = IO.getModifiedTime(asFile)
+  def lastModified: Long = IO.lastModified(asFile)
 
   /**
    * True if and only if the wrapped file `asFile` exists and the file 'other'
@@ -277,7 +278,7 @@ object Path extends Mapper {
     separated.mkString(sep)
   }
   def newerThan(a: File, b: File): Boolean =
-    a.exists && (!b.exists || IO.getModifiedTime(a) > IO.getModifiedTime(b))
+    a.exists && (!b.exists || IO.lastModified(a) > IO.lastModified(b))
 
   /** The separator character of the platform.*/
   val sep: Char = java.io.File.separatorChar

--- a/io/src/main/scala/sbt/io/Path.scala
+++ b/io/src/main/scala/sbt/io/Path.scala
@@ -21,7 +21,7 @@ final class RichFile(val asFile: File) extends AnyVal with RichNioPath {
   def isDirectory: Boolean = asFile.isDirectory
 
   /** The last modified time of the wrapped file.*/
-  def lastModified: Long = IO.lastModified(asFile)
+  def lastModified: Long = IO.getModifiedTimeOrZero(asFile)
 
   /**
    * True if and only if the wrapped file `asFile` exists and the file 'other'
@@ -278,7 +278,7 @@ object Path extends Mapper {
     separated.mkString(sep)
   }
   def newerThan(a: File, b: File): Boolean =
-    a.exists && (!b.exists || IO.lastModified(a) > IO.lastModified(b))
+    a.exists && (!b.exists || IO.getModifiedTimeOrZero(a) > IO.getModifiedTimeOrZero(b))
 
   /** The separator character of the platform.*/
   val sep: Char = java.io.File.separatorChar

--- a/io/src/main/scala/sbt/io/PollingWatchService.scala
+++ b/io/src/main/scala/sbt/io/PollingWatchService.scala
@@ -94,7 +94,7 @@ class PollingWatchService(delay: FiniteDuration) extends WatchService {
       watched.toSeq.sortBy(_._1)(pathLengthOrdering).foreach {
         case (p, _) =>
           if (!results.contains(p))
-            p.toFile.allPaths.get.foreach(f => results += f.toPath -> IO.lastModified(f))
+            p.toFile.allPaths.get.foreach(f => results += f.toPath -> IO.getModifiedTimeOrZero(f))
       }
       results.toMap
     }

--- a/io/src/main/scala/sbt/io/PollingWatchService.scala
+++ b/io/src/main/scala/sbt/io/PollingWatchService.scala
@@ -14,7 +14,6 @@ import java.util.{ List => JList }
 import sbt.io.syntax._
 import scala.collection.mutable
 import scala.concurrent.duration.{ Duration, FiniteDuration }
-import sbt.io.IO
 
 /** A `WatchService` that polls the filesystem every `delay`. */
 class PollingWatchService(delay: FiniteDuration) extends WatchService {

--- a/io/src/main/scala/sbt/io/PollingWatchService.scala
+++ b/io/src/main/scala/sbt/io/PollingWatchService.scala
@@ -14,6 +14,7 @@ import java.util.{ List => JList }
 import sbt.io.syntax._
 import scala.collection.mutable
 import scala.concurrent.duration.{ Duration, FiniteDuration }
+import sbt.io.IO
 
 /** A `WatchService` that polls the filesystem every `delay`. */
 class PollingWatchService(delay: FiniteDuration) extends WatchService {
@@ -93,7 +94,7 @@ class PollingWatchService(delay: FiniteDuration) extends WatchService {
       watched.toSeq.sortBy(_._1)(pathLengthOrdering).foreach {
         case (p, _) =>
           if (!results.contains(p))
-            p.toFile.allPaths.get.foreach(f => results += f.toPath -> IO.getModifiedTime(f))
+            p.toFile.allPaths.get.foreach(f => results += f.toPath -> IO.lastModified(f))
       }
       results.toMap
     }

--- a/io/src/test/scala/sbt/internal/io/SourceModificationWatchSpec.scala
+++ b/io/src/test/scala/sbt/internal/io/SourceModificationWatchSpec.scala
@@ -21,10 +21,9 @@ abstract class SourceModificationWatchSpec(
 
     IO.write(file, "foo")
 
-    // watchTest(parentDir) {
-    //   IO.write(file, "bar")
-    // }
-    pending // until fixed https://github.com/sbt/io/issues/82
+    watchTest(parentDir) {
+      IO.write(file, "bar")
+    }
   }
 
   it should "watch a directory for file creation" in IO.withTemporaryDirectory { dir =>


### PR DESCRIPTION
Ref https://github.com/sbt/io/pull/92

There are just too many instances in which sbt's code relies on
the `lastModified`/`setLastModified` semantics, so instead of moving
to `get`/`setModifiedTime`, we use new IO calls that offer the new
timestamp precision, but retain the old semantics.