### PR TITLE
Convert ERROR_PATH_NOT_FOUND to FileNotFoundException in WinMilli

### DIFF
--- a/io/src/main/scala/sbt/internal/io/Milli.scala
+++ b/io/src/main/scala/sbt/internal/io/Milli.scala
@@ -31,6 +31,7 @@ import com.sun.jna.platform.win32.WinNT.HANDLE
 import com.sun.jna.platform.win32.WinBase.INVALID_HANDLE_VALUE
 import com.sun.jna.platform.win32.WinBase.FILETIME
 import com.sun.jna.platform.win32.WinError.ERROR_FILE_NOT_FOUND
+import com.sun.jna.platform.win32.WinError.ERROR_PATH_NOT_FOUND
 
 import sbt.internal.io.MacJNA._
 
@@ -269,7 +270,7 @@ private object WinMilli extends MilliNative[FILETIME] {
                            null)
     if (hFile == INVALID_HANDLE_VALUE) {
       val err = GetLastError()
-      if (err == ERROR_FILE_NOT_FOUND)
+      if (err == ERROR_FILE_NOT_FOUND || err == ERROR_PATH_NOT_FOUND)
         throw new FileNotFoundException("Not found: " + lpFileName)
       else
         throw new IOException("CreateFile() failed with error " + GetLastError())


### PR DESCRIPTION
Windows has two different error codes for files that do not exist:
ERROR_FILE_NOT_FOUND and ERROR_PATH_NOT_FOUND. We must catch both.

Fixes https://github.com/sbt/sbt/issues/3871