### PR TITLE
align exception from file-timestamp functions from different impl.

### DIFF
--- a/io/src/main/scala/sbt/internal/io/Milli.scala
+++ b/io/src/main/scala/sbt/internal/io/Milli.scala
@@ -7,7 +7,7 @@ import java.io.File
 import java.util.Date
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
-import java.nio.file.Files
+import java.nio.file.{ Files, NoSuchFileException }
 import java.nio.file.{ Paths => JPaths }
 import java.nio.file.attribute.FileTime
 
@@ -319,11 +319,19 @@ private abstract class MilliMilliseconds extends Milli {
 
 private object JavaMilli extends MilliMilliseconds {
   def getModifiedTime(filePath: String): Long =
-    Files.getLastModifiedTime(JPaths.get(filePath)).toMillis
-  def setModifiedTime(filePath: String, mtime: Long): Unit = {
-    Files.setLastModifiedTime(JPaths.get(filePath), FileTime.fromMillis(mtime))
-    ()
-  }
+    mapNoSuchFileException(Files.getLastModifiedTime(JPaths.get(filePath)).toMillis)
+  def setModifiedTime(filePath: String, mtime: Long): Unit =
+    mapNoSuchFileException {
+      Files.setLastModifiedTime(JPaths.get(filePath), FileTime.fromMillis(mtime))
+      ()
+    }
+
+  private def mapNoSuchFileException[A](f: => A): A =
+    try {
+      f
+    } catch {
+      case e: NoSuchFileException => throw new FileNotFoundException(e.getFile).initCause(e)
+    }
 }
 
 object Milli {

--- a/io/src/test/scala/sbt/io/IOSpec.scala
+++ b/io/src/test/scala/sbt/io/IOSpec.scala
@@ -61,4 +61,8 @@ class IOSpec extends FlatSpec with Matchers {
     val u = IO.toURI(file("src") / "main" / "scala")
     assert(IO.toFile(u) == (file("src") / "main" / "scala"))
   }
+
+  "getModifiedTimeOrZero" should "return 0L if the file doesn't exists" in {
+    assert(IO.getModifiedTimeOrZero(file("/not/existing/path")) == 0L)
+  }
 }


### PR DESCRIPTION
 * The native implementations to get / set a file-timestamp throws
   a 'java.io.FileNotFoundException' where the Java based implementation
   throws a 'java.nio.file.NoSuchFileException' if the given file
   does not exists.

 * 'IO.getModifiedTimeOrZero' and 'IO.setModifiedTimeOrFalse' handles
   only 'java.io.FileNotFoundException'

 * Map 'NoSuchFileExeption' to 'FileNotFoundException' in the
   Java based implementation, so all implementations throws
   the same error.


fixes sbt/sbt/issues/3894