### PR TITLE
Prevent creation of useless URI copies in IO.directoryURI

### DIFF
--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -971,11 +971,13 @@ object IO {
   def directoryURI(uri: URI): URI = {
     if (!uri.isAbsolute) return uri; //assertAbsolute(uri)
     val str = uri.toASCIIString
-    val dirStr =
-      if (str.endsWith("/") || uri.getScheme != FileScheme || Option(uri.getRawFragment).isDefined)
-        str
-      else str + "/"
-    (new URI(dirStr)).normalize
+    val dirURI =
+      if (str.endsWith("/") || uri.getScheme != FileScheme || (uri.getRawFragment ne null))
+        uri
+      else
+        new URI(str + "/")
+
+    dirURI.normalize
   }
 
   /** Converts the given File to a URI.  If the File is relative, the URI is relative, unlike File.toURI*/


### PR DESCRIPTION
Without this change, `Scope.resolveBuild` will create new identical URI copies
for every call leading to potentially hundreds of thousand of URI copies pointing
to the project path potential using a significant share of the configured heap for
sbt.

In big projects, the wasted memory can be hundreds of MBs leading to increased
memory pressure. With a 2.5GB heap I've seen > 10% better project load
performance on big projects.