### PR TITLE
WinMilli: enable read/read/delete/rename sharing

### DIFF
--- a/io/src/main/scala/sbt/internal/io/Milli.scala
+++ b/io/src/main/scala/sbt/internal/io/Milli.scala
@@ -24,6 +24,8 @@ import com.sun.jna.platform.win32.Kernel32
 import com.sun.jna.platform.win32.WinNT.GENERIC_READ
 import com.sun.jna.platform.win32.WinNT.FILE_SHARE_READ
 import com.sun.jna.platform.win32.WinNT.FILE_SHARE_WRITE
+import com.sun.jna.platform.win32.WinNT.FILE_SHARE_DELETE
+import com.sun.jna.platform.win32.WinNT.FILE_READ_ATTRIBUTES
 import com.sun.jna.platform.win32.WinNT.FILE_WRITE_ATTRIBUTES
 import com.sun.jna.platform.win32.WinNT.FILE_FLAG_BACKUP_SEMANTICS
 import com.sun.jna.platform.win32.WinNT.OPEN_EXISTING
@@ -293,7 +295,7 @@ private object WinMilli extends MilliNative[FILETIME] {
   }
 
   protected def getModifiedTimeNative(filePath: String): FILETIME = {
-    val hFile = getHandle(filePath, GENERIC_READ, FILE_SHARE_READ)
+    val hFile = getHandle(filePath, FILE_READ_ATTRIBUTES, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
     val mtime = try {
       val modifiedTime = new FILETIME.ByReference()
       if (!GetFileTime(hFile, /*creationTime*/ null, /*accessTime*/ null, modifiedTime))
@@ -309,7 +311,7 @@ private object WinMilli extends MilliNative[FILETIME] {
   }
 
   protected def setModifiedTimeNative(filePath: String, fileTime: FILETIME): Unit = {
-    val hFile = getHandle(filePath, FILE_WRITE_ATTRIBUTES, FILE_SHARE_WRITE)
+    val hFile = getHandle(filePath, FILE_WRITE_ATTRIBUTES, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
     try {
       if (SetFileTime(hFile, null, null, fileTime) == 0)
         throw new IOException(


### PR DESCRIPTION
In Windows, reading or writing file attributes requires opening
the file via CreateFile(). If only FILE_SHARE_READ is specified
when reading the timestamp, the CreateFile() call will fail
when the file happens to be already open for writing. This
pull request specifies that the file that is being opened has
shared read and write access; the shared delete mode (which also
implies rename) is also allowed, and in case the subsequent
timestamp get/set fails (if the file disappears) the usual
exception-to-zero code path will be taken.

See sbt/sbt#3972