### PR TITLE
Add MacOSXWatchService

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ val io = (project in file("io"))
     libraryDependencies ++= {
       if (scalaVersion.value startsWith "2.13.") Vector()
       else Vector(scalaCompiler.value % Test, scalaCheck % Test, scalatest % Test)
-    },
+    } ++ Vector(appleFileEvents),
     libraryDependencies ++= Seq(jna, jnaPlatform),
     sourceManaged in (Compile, generateContrabands) := baseDirectory.value / "src" / "main" / "contraband-scala",
     initialCommands in console += "\nimport sbt.io._, syntax._",

--- a/io/src/main/scala/sbt/io/MacOSXWatchService.scala
+++ b/io/src/main/scala/sbt/io/MacOSXWatchService.scala
@@ -1,0 +1,134 @@
+package sbt.io
+
+import java.nio.file.StandardWatchEventKinds.{ ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY, OVERFLOW }
+import java.nio.file.{ Files, WatchEvent, WatchKey, Path => JPath, Paths => JPaths }
+import java.util.Collections
+import java.util.concurrent._
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger }
+import java.util.{ List => JList }
+
+import com.swoval.concurrent.ThreadFactory
+import com.swoval.files.apple.FileEventsApi.Consumer
+import com.swoval.files.apple.{ FileEvent, FileEventsApi, Flags }
+
+import scala.collection.mutable
+import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+
+class MacOSXWatchService extends WatchService {
+  // The FsEvents api doesn't seem to report events at lower than 10 millisecond intervals.
+  private[this] val watchLatency: Duration = 10.milliseconds
+  private[this] val queueSize = 256
+
+  private[this] val executor =
+    Executors.newSingleThreadExecutor(new ThreadFactory("sbt.io.MacOSXWatchService"))
+  private[this] val dropEvent = new Consumer[String] {
+    override def accept(s: String): Unit = {}
+  }
+  private val onFileEvent = new Consumer[FileEvent] {
+    override def accept(fileEvent: FileEvent): Unit = {
+      executor.submit(new Runnable {
+        override def run(): Unit = {
+          val path = JPaths.get(fileEvent.fileName)
+          registered.synchronized(registered.get(path.getParent).foreach { key =>
+            val exists = Files.exists(path)
+            if (exists && key.reportModifyEvents) createEvent(key, ENTRY_MODIFY, path)
+            else if (!exists && key.reportDeleteEvents) createEvent(key, ENTRY_DELETE, path)
+          })
+        }
+      })
+      ()
+    }
+  }
+
+  private[this] val watcher: FileEventsApi = FileEventsApi.apply(onFileEvent, dropEvent)
+  override def close(): Unit = {
+    if (open.compareAndSet(true, false)) {
+      watcher.close()
+      executor.shutdownNow()
+      ()
+    }
+  }
+
+  override def init(): Unit = {}
+
+  override def poll(timeout: Duration): WatchKey = {
+    readyKeys.poll(timeout.toNanos, TimeUnit.NANOSECONDS)
+  }
+
+  override def pollEvents(): Map[WatchKey, Seq[WatchEvent[JPath]]] =
+    registered
+      .synchronized(registered.flatMap {
+        case (_, k) =>
+          val events = k.pollEvents()
+          if (events.isEmpty) None
+          else Some(k -> events.asScala.map(_.asInstanceOf[WatchEvent[JPath]]))
+      })
+      .toMap[WatchKey, Seq[WatchEvent[JPath]]]
+
+  override def register(path: JPath, events: WatchEvent.Kind[JPath]*): WatchKey = {
+    registered.synchronized {
+      registered get path match {
+        case Some(k) => k;
+        case _ =>
+          val key = new MacOSXWatchKey(path, queueSize, events: _*)
+          registered += path -> key
+          val flags = new Flags.Create().setNoDefer().setFileEvents().value
+          watcher.createStream(path.toRealPath().toString, watchLatency.toMillis / 1000.0, flags)
+          key
+      }
+    }
+  }
+
+  private def createEvent(key: MacOSXWatchKey, kind: WatchEvent.Kind[JPath], file: JPath): Unit = {
+    val event = Event(kind, 1, file)
+    key.addEvent(event)
+    if (!readyKeys.contains(key)) {
+      readyKeys.offer(key)
+    }
+    ()
+  }
+
+  def isOpen: Boolean = open.get
+
+  private[this] val open = new AtomicBoolean(true)
+  private[this] val readyKeys = new LinkedBlockingQueue[MacOSXWatchKey]
+  private[this] val registered = mutable.Map.empty[JPath, MacOSXWatchKey]
+}
+
+private case class Event[T](kind: WatchEvent.Kind[T], count: Int, context: T) extends WatchEvent[T]
+
+private class MacOSXWatchKey(val watchable: JPath, queueSize: Int, kinds: WatchEvent.Kind[JPath]*)
+    extends WatchKey {
+
+  override def cancel(): Unit = valid.set(false)
+
+  override def isValid: Boolean = valid.get
+
+  override def pollEvents(): JList[WatchEvent[_]] = {
+    val result = new mutable.ArrayBuffer[WatchEvent[_]](events.size).asJava
+    events.drainTo(result)
+    val overflowCount = overflow.getAndSet(0)
+    if (overflowCount != 0) {
+      result.add(Event(OVERFLOW, overflowCount, watchable))
+    }
+    Collections.unmodifiableList(result)
+  }
+
+  override def reset(): Boolean = { events.clear(); true }
+
+  override def toString = s"MacOSXWatchKey($watchable)"
+
+  lazy val reportCreateEvents: Boolean = kinds contains ENTRY_CREATE
+  lazy val reportModifyEvents: Boolean = kinds contains ENTRY_MODIFY
+  lazy val reportDeleteEvents: Boolean = kinds contains ENTRY_DELETE
+
+  private val events = new ArrayBlockingQueue[WatchEvent[_]](queueSize)
+  private val overflow = new AtomicInteger()
+  private val valid = new AtomicBoolean(true)
+
+  @inline def addEvent(event: Event[JPath]): Unit = if (!events.offer(event)) {
+    overflow.incrementAndGet()
+    ()
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,4 +13,5 @@ object Dependencies {
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.3"
   val jna = "net.java.dev.jna" % "jna" % "4.5.0"
   val jnaPlatform = "net.java.dev.jna" % "jna-platform" % "4.5.0"
+  val appleFileEvents = "com.swoval" % "apple-file-events" % "1.3.0"
 }


### PR DESCRIPTION
This watch service is taken from my CloseWatch plugin, found at
https://github.com/swoval/swoval

It uses a native jni library, provided by apple-file-events, to receive
file events from the os. I more or less copied this file from the close
watch source code with some minor modifications given that it is now in
the sbt.io package.