### PR TITLE
Handle null WatchEvent context

### DIFF
--- a/io/src/main/scala/sbt/internal/io/SourceModificationWatch.scala
+++ b/io/src/main/scala/sbt/internal/io/SourceModificationWatch.scala
@@ -67,7 +67,10 @@ private[sbt] object SourceModificationWatch {
   private def expandEvent(event: (Path, WatchEvent[_])): (Path, WatchEvent.Kind[Path]) = {
     event match {
       case (base, ev) =>
-        val fullPath = base.resolve(ev.context().asInstanceOf[Path])
+        val fullPath = Option(ev.context().asInstanceOf[Path]) match {
+          case Some(path) => base.resolve(path)
+          case None       => base
+        }
         val kind = ev.kind().asInstanceOf[WatchEvent.Kind[Path]]
         (fullPath, kind)
     }


### PR DESCRIPTION
WatchEvent.context() can return null for OVERFLOW events (https://docs.oracle.com/javase/8/docs/api/java/nio/file/StandardWatchEventKinds.html#OVERFLOW).
The context was treated as a valid path, even when it was null. This commit prevents a NullPointerException from being thrown in this case.

Fixes #112