### PR TITLE
prepare Scala 2.13.0-M4

### DIFF
--- a/io/src/main/scala/sbt/internal/io/SourceModificationWatch.scala
+++ b/io/src/main/scala/sbt/internal/io/SourceModificationWatch.scala
@@ -37,8 +37,8 @@ private[sbt] object SourceModificationWatch {
       } else {
         val previousFiles = state.registered.keySet
         val newFiles = state.sources.flatMap(_.getUnfilteredPaths()).toSet
-        val createdFiles = newFiles -- previousFiles
-        val deletedFiles = previousFiles -- newFiles
+        val createdFiles = newFiles diff previousFiles
+        val deletedFiles = previousFiles diff newFiles
 
         // We may have events that are not relevant (e.g., created an empty directory.)
         // We filter out those changes, so that we don't trigger unnecessarily.

--- a/io/src/main/scala/sbt/io/PathMapper.scala
+++ b/io/src/main/scala/sbt/io/PathMapper.scala
@@ -171,5 +171,5 @@ abstract class Mapper {
   private[this] def fold[A, B, T](zero: A => Option[B], in: Iterable[T])(
       f: T => A => Option[B]
   ): A => Option[B] =
-    (zero /: in)((mapper, base) => f(base) | mapper)
+    in.foldLeft(zero)((mapper, base) => f(base) | mapper)
 }

--- a/io/src/main/scala/sbt/io/PollingWatchService.scala
+++ b/io/src/main/scala/sbt/io/PollingWatchService.scala
@@ -111,8 +111,8 @@ class PollingWatchService(delay: FiniteDuration) extends WatchService {
       val newFiles = newFileTimes.keySet
       val oldFiles = fileTimes.keySet
 
-      val deletedFiles = (oldFiles -- newFiles).toSeq
-      val createdFiles = (newFiles -- oldFiles).toSeq
+      val deletedFiles = (oldFiles diff newFiles).toSeq
+      val createdFiles = (newFiles diff oldFiles).toSeq
 
       val modifiedFiles = fileTimes.collect {
         case (p, oldTime) if newFileTimes.getOrElse(p, 0L) > oldTime => p


### PR DESCRIPTION
- use `Set#diff` instead of `Set#--` https://github.com/scala/scala/blob/5661290bfda0a08a60fb8df3ac60baafb55c0306/src/library/scala/collection/Set.scala#L154
- use `foldLeft` instead of `/:` https://github.com/scala/scala/blob/5661290bfda0a08a60fb8df3ac60baafb55c0306/src/library/scala/collection/IterableOnce.scala#L465