### PR TITLE
fix compile error in Scala 2.13.0-M4

### DIFF
--- a/io/src/main/scala/sbt/internal/io/EventMonitor.scala
+++ b/io/src/main/scala/sbt/internal/io/EventMonitor.scala
@@ -127,7 +127,7 @@ private[sbt] object EventMonitor {
         recentEvents = recentEvents.filterNot(_._2.isOverdue)
         getFilesForKey(s.service.poll(delay)).foreach(maybeTrigger)
       }
-      def getFilesForKey(key: WatchKey): Seq[Path] = key match {
+      def getFilesForKey(key: WatchKey): collection.Seq[Path] = key match {
         case null => Nil
         case k =>
           val allEvents = k.pollEvents.asScala

--- a/io/src/main/scala/sbt/io/MacOSXWatchService.scala
+++ b/io/src/main/scala/sbt/io/MacOSXWatchService.scala
@@ -75,15 +75,15 @@ class MacOSXWatchService extends WatchService with Unregisterable {
       readyKeys.poll(timeout.toNanos, TimeUnit.NANOSECONDS)
     } else throw new ClosedWatchServiceException
 
-  override def pollEvents(): Map[WatchKey, Seq[WatchEvent[JPath]]] =
+  override def pollEvents(): Map[WatchKey, collection.Seq[WatchEvent[JPath]]] =
     registered
       .synchronized(registered.flatMap {
         case (_, (k, _)) =>
           val events = k.pollEvents()
-          if (events.isEmpty) None
-          else Some(k -> events.asScala.map(_.asInstanceOf[WatchEvent[JPath]]))
+          if (events.isEmpty) Nil
+          else Seq(k -> events.asScala.map(_.asInstanceOf[WatchEvent[JPath]]))
       })
-      .toMap[WatchKey, Seq[WatchEvent[JPath]]]
+      .toMap[WatchKey, collection.Seq[WatchEvent[JPath]]]
 
   override def register(path: JPath, events: WatchEvent.Kind[JPath]*): WatchKey = {
     if (isOpen) {

--- a/io/src/main/scala/sbt/io/WatchService.scala
+++ b/io/src/main/scala/sbt/io/WatchService.scala
@@ -103,7 +103,7 @@ trait WatchService {
    * Does not wait if no event is available.
    * @return The pending events.
    */
-  def pollEvents(): Map[WatchKey, Seq[WatchEvent[JPath]]]
+  def pollEvents(): Map[WatchKey, collection.Seq[WatchEvent[JPath]]]
 
   /**
    * Retrieves the next `WatchKey` that has a `WatchEvent` waiting. Waits


### PR DESCRIPTION
- https://github.com/scala/community-builds/issues/710
- https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/1092/consoleFull

```
[sbt-io] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.12/project-builds/sbt-io-1aeb11a3d751ba13cb0d1d22d082306f3c24a209/io/src/main/scala/sbt/io/MacOSXWatchService.scala:61:32: overloaded method value flatMap with alternatives:
[sbt-io] [error]   [K2, V2](f: ((java.nio.file.Path, sbt.io.MacOSXWatchKey)) => scala.collection.IterableOnce[(K2, V2)])scala.collection.mutable.Map[K2,V2] <and>
[sbt-io] [error]   [B](f: ((java.nio.file.Path, sbt.io.MacOSXWatchKey)) => scala.collection.IterableOnce[B])scala.collection.mutable.Iterable[B]
[sbt-io] [error]  cannot be applied to (((java.nio.file.Path, sbt.io.MacOSXWatchKey)) => Option[(sbt.io.MacOSXWatchKey, scala.collection.mutable.Buffer[java.nio.file.WatchEvent[java.nio.file.Path]])])
[sbt-io] [error]       .synchronized(registered.flatMap {
[sbt-io] [error]                                ^
[sbt-io] [error] /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.12/project-builds/sbt-io-1aeb11a3d751ba13cb0d1d22d082306f3c24a209/io/src/main/scala/sbt/io/MacOSXWatchService.scala:61:32: overloaded method value flatMap with alternatives:
[sbt-io] [error]   [K2, V2](f: ((java.nio.file.Path, sbt.io.MacOSXWatchKey)) => scala.collection.IterableOnce[(K2, V2)])scala.collection.mutable.Map[K2,V2] <and>
[sbt-io] [error]   [B](f: ((java.nio.file.Path, sbt.io.MacOSXWatchKey)) => scala.collection.IterableOnce[B])scala.collection.mutable.Iterable[B]
[sbt-io] [error]  cannot be applied to (((java.nio.file.Path, sbt.io.MacOSXWatchKey)) => Option[(sbt.io.MacOSXWatchKey, scala.collection.mutable.Buffer[java.nio.file.WatchEvent[java.nio.file.Path]])])
[sbt-io] [error]       .synchronized(registered.flatMap {
[sbt-io] [error]                                ^
[sbt-io] [warn] one warning found
[sbt-io] [error] one error found
[sbt-io] [info] No documentation generated with unsuccessful compiler run
[sbt-io] [warn] two warnings found
[sbt-io] [error] one error found
[sbt-io] [error] (io / Compile / compileIncremental) Compilation failed
[sbt-io] [error] (io / Compile / doc) Scaladoc generation failed
```