### PR TITLE
Add sleep to user input thread

### DIFF
--- a/io/src/main/scala/sbt/internal/io/EventMonitor.scala
+++ b/io/src/main/scala/sbt/internal/io/EventMonitor.scala
@@ -186,6 +186,7 @@ private[sbt] object EventMonitor {
                                  logger: Logger): Looper =
     new Looper(s"watch-state-user-input-${userInputId.incrementAndGet}") {
       override final def loop(): Unit = {
+        Thread.sleep(10)
         if (terminationCondition) {
           logger.debug("Received termination condition. Stopping watch...")
           events.peek match {


### PR DESCRIPTION
I didn't realize that System.in.read is not interruptible, so it was
problematic* to change the downstream termination condition from:
-  System.in.available > 0 && (watched.terminateWatch(System.in.read()) || shouldTerminate)
+  watched.terminateWatch(System.in.read()) || shouldTerminate

Instead, we should revert to the old termination condition and add a
sleep so that we don't peg the cpu.

* This would manifest as the user having to hit enter twice to exit the
watch in some circumstances because the user input thread could not be
joined.