### PR TITLE
Fix file watching for unix

### DIFF
--- a/io/src/main/scala/sbt/io/MacOSXWatchService.scala
+++ b/io/src/main/scala/sbt/io/MacOSXWatchService.scala
@@ -155,7 +155,7 @@ private class MacOSXWatchKey(val watchable: JPath, queueSize: Int, kinds: WatchE
     Collections.unmodifiableList(result)
   }
 
-  override def reset(): Boolean = { events.clear(); true }
+  override def reset(): Boolean = true
 
   override def toString = s"MacOSXWatchKey($watchable)"
 


### PR DESCRIPTION
I inadvertently forgot to reset the watch key after reading the events.
This would cause the EventMonitor to miss watch events because the watch
service stopped posting events to the full key. I looked at the jdk
source code and it looks like each watch key can hold up to 512 events,
so I added a test to ensure that after adding 1000 files, watch events
were still triggered. The test failed before the change to EventMonitor.
I also realized that I reintroduced the bug fixed by @oneill in
881e835a56ef9f7df15075fd6abb62c122bae2af so I fixed that as well.