### PR TITLE
Add FileVisitOption.FOLLOW_LINKS option

### DIFF
--- a/io/src/main/scala/sbt/io/Path.scala
+++ b/io/src/main/scala/sbt/io/Path.scala
@@ -10,6 +10,7 @@ import scala.collection.mutable
 import java.nio.file.attribute._
 import java.nio.file.{
   FileSystem,
+  FileVisitOption,
   FileVisitResult,
   FileVisitor,
   Files,
@@ -450,6 +451,8 @@ private class DescendantOrSelfPathFinder(val parent: PathFinder, val filter: Fil
   private def handleFileDescendant(file: File, fileSet: mutable.Set[File]): Unit = {
     Files.walkFileTree(
       file.toPath,
+      mutable.Set(FileVisitOption.FOLLOW_LINKS).asJava,
+      java.lang.Integer.MAX_VALUE,
       new FileVisitor[NioPath] {
         override def preVisitDirectory(dir: NioPath,
                                        attrs: BasicFileAttributes): FileVisitResult = {

--- a/io/src/test/scala/sbt/io/PathFinderSpec.scala
+++ b/io/src/test/scala/sbt/io/PathFinderSpec.scala
@@ -1,0 +1,33 @@
+package sbt.io
+
+import java.nio.file.Files
+
+import org.scalatest.{ FlatSpec, Matchers }
+
+class PathFinderSpec extends FlatSpec with Matchers {
+  "PathFinder" should "find the files in a directory" in IO.withTemporaryDirectory { dir =>
+    val foo = Files.createTempFile(dir.toPath, "foo", "").toFile
+    val bar = Files.createTempFile(dir.toPath, "bar", "").toFile
+    PathFinder(dir).allPaths.get.toSet shouldBe Set(dir, foo, bar)
+  }
+  it should "find children of subdirectories" in IO.withTemporaryDirectory { dir =>
+    val subdir = Files.createTempDirectory(dir.toPath, "subdir")
+    val foo = Files.createTempFile(subdir, "foo", "").toFile
+    PathFinder(dir).allPaths.get.toSet shouldBe Set(dir, subdir.toFile, foo)
+  }
+  it should "apply filter" in IO.withTemporaryDirectory { dir =>
+    val foo = Files.createTempFile(dir.toPath, "foo", "").toFile
+    Files.createTempFile(dir.toPath, "bar", "").toFile
+    val include = new SimpleFilter(_.startsWith("foo"))
+    PathFinder(dir).descendantsExcept(include, NothingFilter).get shouldBe Seq(foo)
+  }
+  it should "follow links" in IO.withTemporaryDirectory { dir =>
+    IO.withTemporaryDirectory { otherDir =>
+      val foo = Files.createTempFile(otherDir.toPath, "foo", "")
+      val link = Files.createSymbolicLink(dir.toPath.resolve("link"), otherDir.toPath)
+      PathFinder(dir).allPaths.get.toSet shouldBe Set(dir,
+                                                      link.toFile,
+                                                      link.resolve(foo.getFileName).toFile)
+    }
+  }
+}


### PR DESCRIPTION
I discovered that 7186d1f28dc4f04422fa9de22eb76b0c666de3ce did not have
exactly the same semantics as before. There wasn't a test for this (or
for PathFinder in general), so I added one along with a few basic tests
for PathFinder.

Fixes #161