### PR TITLE
Fixes file deletion error on Windows 2

### DIFF
--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -12,15 +12,14 @@ import java.io.{
   BufferedWriter,
   File,
   InputStream,
-  IOException,
   OutputStream,
   PrintWriter
 }
 import java.io.{ ObjectInputStream, ObjectStreamClass, FileNotFoundException }
 import java.net.{ URI, URISyntaxException, URL }
 import java.nio.charset.Charset
-import java.nio.file.{FileSystems, Files, Paths, Path, SimpleFileVisitor, FileVisitResult}
-import java.nio.file.attribute.{PosixFilePermissions, BasicFileAttributes}
+import java.nio.file.FileSystems
+import java.nio.file.attribute.PosixFilePermissions
 import java.util.Properties
 import java.util.jar.{ Attributes, JarEntry, JarOutputStream, Manifest }
 import java.util.zip.{ CRC32, ZipEntry, ZipInputStream, ZipOutputStream }
@@ -455,24 +454,14 @@ object IO {
 
   /** Deletes `file`, recursively if it is a directory. */
   def delete(file: File): Unit = {
-    object deleter extends SimpleFileVisitor[Path] {
-      override def visitFile(file: Path, attr: BasicFileAttributes): FileVisitResult = {
-        translate("Error deleting file " + file.toFile + ": "){
-          Files.delete(file)
-        }
-        FileVisitResult.CONTINUE
-      }
-
-      override def postVisitDirectory(dir: Path, e: IOException): FileVisitResult = {
-        if (e eq null) {
-          translate("Error deleting file " + dir.toFile + ": ") {
-            Files.delete(dir)
-          }
-          FileVisitResult.CONTINUE
-        } else throw e // directory iteration failed
+    translate("Error deleting file " + file + ": ") {
+      val deleted = file.delete()
+      if (!deleted && file.isDirectory) {
+        delete(listFiles(file))
+        file.delete
+        ()
       }
     }
-    Files.walkFileTree(file.toPath, deleter)
   }
 
   /** Returns the children of directory `dir` that match `filter` in a non-null array.*/


### PR DESCRIPTION
Fixes #169 by reverting #135 

This is based on my observation that the original implementation runs fastest on Windows on Virtualbox.

```
old delete 1 took 2714.851 ms
delete #135 1 took 3623.421 ms
delete #170 1 took 2850.538 ms
old delete 2 took 2716.804 ms
delete #135 2 took 3732.995 ms
delete #170 2 took 2819.38 ms
old delete 3 took 2747.379 ms
delete #135 3 took 3769.503 ms
delete #170 3 took 2888.485 ms
old delete 4 took 2737.943 ms
delete #135 4 took 3727.32 ms
delete #170 4 took 2889.788 ms
old delete 5 took 2828.599 ms
delete #135 5 took 3677.875 ms
delete #170 5 took 2863.272 ms
```
