### PR TITLE
File watch overhaul

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,6 +64,16 @@ val io = (project in file("io"))
 
       // protected[this]
       exclude[DirectMissingMethodProblem]("sbt.io.CopyOptions.copy*"),
+
+      // private class
+      exclude[MissingClassProblem]("sbt.io.Event"),
+      exclude[MissingClassProblem]("sbt.io.Event$"),
+      exclude[MissingClassProblem]("sbt.io.MacOSXWatchKey"),
+
+      // private internal classes whose functionality has been replaced
+      exclude[MissingClassProblem]("sbt.internal.io.EventMonitor$*"),
+      exclude[DirectMissingMethodProblem]("sbt.internal.io.EventMonitor.legacy"),
+      exclude[DirectMissingMethodProblem]("sbt.internal.io.EventMonitor.applyImpl")
     ),
     BuildInfoPlugin.buildInfoDefaultSettings, // avoids BuildInfo generated in Compile scope
     addBuildInfoToConfig(Test),

--- a/build.sbt
+++ b/build.sbt
@@ -54,9 +54,18 @@ val io = (project in file("io"))
       // MiMa doesn't understand private inner classes?
       // method this(sbt.io.PollingWatchService,sbt.io.PollingWatchService#PollingThread,java.nio.file.Watchable,java.util.List)Unit in class sbt.io.PollingWatchService#PollingWatchKey does not have a correspondent in current version
       exclude[DirectMissingMethodProblem]("sbt.io.PollingWatchService#PollingWatchKey.this"),
+      exclude[IncompatibleMethTypeProblem]("sbt.io.PollingWatchService#PollingWatchKey.this"),
 
       // This is a private class
       exclude[DirectMissingMethodProblem]("sbt.io.PollingWatchService#PollingWatchKey.events"),
+      exclude[DirectMissingMethodProblem]("sbt.io.PollingWatchService#PollingWatchKey.offer"),
+
+      // This is a private class
+      exclude[DirectMissingMethodProblem]("sbt.io.PollingWatchService#PollingThread.events"),
+      exclude[DirectMissingMethodProblem]("sbt.io.PollingWatchService#PollingThread.initDone"),
+      exclude[DirectMissingMethodProblem]("sbt.io.PollingWatchService#PollingThread.initDone_="),
+      exclude[DirectMissingMethodProblem]("sbt.io.PollingWatchService#PollingThread.keysWithEvents"),
+      exclude[DirectMissingMethodProblem]("sbt.io.PollingWatchService#PollingThread.getFileTimes"),
 
       // moved JavaMilli to sbt.io
       exclude[MissingClassProblem]("sbt.internal.io.JavaMilli$"),

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ val io = (project in file("io"))
     name := "IO",
     libraryDependencies ++= {
       Vector(scalaCompiler.value % Test, scalaCheck % Test, scalatest.value % Test)
-    } ++ Vector(appleFileEvents),
+    } ++ Vector(swovalFiles),
     libraryDependencies ++= Seq(jna, jnaPlatform),
     sourceManaged in (Compile, generateContrabands) := baseDirectory.value / "src" / "main" / "contraband-scala",
     initialCommands in console += "\nimport sbt.io._, syntax._",

--- a/io/src/main/scala/sbt/internal/io/DefaultFileTreeView.scala
+++ b/io/src/main/scala/sbt/internal/io/DefaultFileTreeView.scala
@@ -1,0 +1,53 @@
+package sbt.internal.io
+
+import java.nio.file.{ NoSuchFileException, NotDirectoryException, Path }
+
+import com.swoval.files.{ TypedPath => STypedPath }
+import com.swoval.files.FileTreeViews
+import com.swoval.functional.Filters
+import sbt.io.{ FileTreeView, TypedPath }
+
+import scala.collection.JavaConverters._
+import SwovalConverters._
+
+import scala.util.Try
+
+private[sbt] object DefaultFileTreeView extends FileTreeView {
+  private[this] val fileTreeView =
+    if ("nio" == sys.props.getOrElse("sbt.pathfinder", ""))
+      FileTreeViews.getNio(true)
+    else
+      FileTreeViews.getDefault(true)
+
+  /**
+   * List the contents of the current directory
+   *
+   * @param path      the path to list
+   * @param maxDepth  controls the depth of children of the path to include in the results. When
+   *                  maxDepth is -1, [[list]] should only return the TypedPath for this directory.
+   *                  For non-negative values, [[list]] should return only entries whose relativized
+   *                  path has {{{maxDepth - 1}}} elements. For example, when maxDepth is zero, all of
+   *                  the children of the path should be included in the result, but none of the
+   *                  children of any of the subdirectories should be incldued.
+   *
+   * @param filter    only return files accepted by the filter
+   * @return a sequence of [[TypedPath]].
+   */
+  override def list(path: Path, maxDepth: Int, filter: TypedPath => Boolean): Seq[TypedPath] = {
+    try {
+      fileTreeView
+        .list(path, maxDepth, Filters.AllPass)
+        .asScala
+        .toSeq
+        .flatMap((_: STypedPath).asSbt match {
+          case tp if filter(tp) => Some(tp)
+          case _                => None
+        })
+    } catch {
+      case _: NotDirectoryException | _: NoSuchFileException =>
+        Try(Seq(TypedPath(path))).getOrElse(Nil)
+    }
+  }
+
+  override def close(): Unit = ()
+}

--- a/io/src/main/scala/sbt/internal/io/EventMonitor.scala
+++ b/io/src/main/scala/sbt/internal/io/EventMonitor.scala
@@ -167,7 +167,7 @@ private[sbt] object EventMonitor {
        */
       private def handleOverflow(key: WatchKey): Vector[Path] = lock.synchronized {
         val allFiles = new mutable.HashSet[Path]
-        def getNewFiles(): Unit = {
+        def addNewFiles(): Unit = {
           allFiles.clear()
           val path = key.watchable.asInstanceOf[Path]
           Files.walkFileTree(
@@ -195,7 +195,7 @@ private[sbt] object EventMonitor {
         var oldFiles = mutable.Set.empty[Path]
         do {
           oldFiles = allFiles
-          getNewFiles()
+          addNewFiles()
         } while (oldFiles != allFiles)
         registered --= registered.collect {
           case (d, k) if !Files.exists(d) =>

--- a/io/src/main/scala/sbt/internal/io/EventMonitor.scala
+++ b/io/src/main/scala/sbt/internal/io/EventMonitor.scala
@@ -106,10 +106,8 @@ private[sbt] object EventMonitor {
 
   private[io] def legacy(state: WatchState,
                          delay: FiniteDuration,
-                         terminationCondition: => Boolean): EventMonitor = {
-    val tc = () => { val res = terminationCondition; if (!res) Thread.sleep(10); res }
-    applyImpl(state, delay, 40.milliseconds, tc(), NullLogger, closeService = false)
-  }
+                         terminationCondition: => Boolean): EventMonitor =
+    applyImpl(state, delay, 40.milliseconds, terminationCondition, NullLogger, closeService = false)
 
   private trait HasWatchState {
     def state(): WatchState

--- a/io/src/main/scala/sbt/internal/io/EventMonitor.scala
+++ b/io/src/main/scala/sbt/internal/io/EventMonitor.scala
@@ -1,17 +1,11 @@
 package sbt.internal.io
 
-import java.io.IOException
-import java.nio.file.StandardWatchEventKinds.OVERFLOW
 import java.nio.file._
-import java.nio.file.attribute.BasicFileAttributes
-import java.util.concurrent.ArrayBlockingQueue
-import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger }
 
-import sbt.io.WatchService
+import sbt.io
+import sbt.io.{ Path => _, _ }
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
-import scala.collection.mutable
 import scala.concurrent.duration._
 
 /**
@@ -40,49 +34,16 @@ private[sbt] sealed trait EventMonitor extends AutoCloseable {
  * Provides factory methods for creating instances of EventMonitor.
  */
 private[sbt] object EventMonitor {
-  private sealed trait Event
-  private case object Cancelled extends Event
-  private case class Triggered(path: Path) extends Event
-
-  private class EventMonitorImpl private[EventMonitor] (
-      private[this] val service: WatchService,
-      private[this] val events: ArrayBlockingQueue[Event],
-      private[this] val eventThread: Looper with HasWatchState,
-      private[this] val userInputThread: Looper,
-      private[this] val logger: Logger,
-      private[this] val closeService: Boolean)
-      extends EventMonitor {
-
-    override def state(): WatchState = eventThread.state()
-
-    override def awaitEvent(): Boolean = events.take() match {
-      case Cancelled => false
-      case Triggered(path) =>
-        logger.debug(s"Triggered watch event due to updated path: $path")
-        eventThread.incrementCount()
-        true
-    }
-
-    override def close(): Unit = {
-      if (closed.compareAndSet(false, true)) {
-        if (closeService) service.close()
-        userInputThread.close()
-        eventThread.close()
-        logger.debug("Closed EventMonitor")
-      }
-    }
-
-    private[this] val closed = new AtomicBoolean(false)
-  }
 
   /**
    * Create a new EventMonitor
-   * @param state The initial watch state for the monitor
-   * @param delay Maximum duration that the monitor will poll the watch service for events
-   * @param antiEntropy Minimum duration that must elapse before a build may by re-triggered by
-   *                    the same file
+   *
+   * @param state                The initial watch state for the monitor
+   * @param delay                Maximum duration that the monitor will poll the watch service for events
+   * @param antiEntropy          Minimum duration that must elapse before a build may by re-triggered by
+   *                             the same file
    * @param terminationCondition Exits watch if evaluates to true
-   * @param logger
+   * @param logger               Logs output
    * @return The new EventMonitor
    */
   def apply(state: WatchState,
@@ -92,215 +53,58 @@ private[sbt] object EventMonitor {
             logger: Logger = NullLogger): EventMonitor =
     applyImpl(state, delay, antiEntropy, terminationCondition, logger, closeService = true)
 
-  private[EventMonitor] def applyImpl(state: WatchState,
-                                      delay: FiniteDuration,
-                                      antiEntropy: FiniteDuration,
-                                      terminationCondition: => Boolean,
-                                      logger: Logger,
-                                      closeService: Boolean): EventMonitor = {
-    val events = new ArrayBlockingQueue[Event](1)
-    val eventThread = newEventsThread(delay, antiEntropy, state, events, logger)
-    val userInputThread = newUserInputThread(terminationCondition, events, logger)
-    new EventMonitorImpl(state.service, events, eventThread, userInputThread, logger, closeService)
-  }
-
   private[io] def legacy(state: WatchState,
                          delay: FiniteDuration,
                          terminationCondition: => Boolean): EventMonitor =
     applyImpl(state, delay, 40.milliseconds, terminationCondition, NullLogger, closeService = false)
 
-  private trait HasWatchState {
-    def state(): WatchState
-    def incrementCount(): Unit
-  }
-  private def newEventsThread(delay: FiniteDuration,
-                              antiEntropy: FiniteDuration,
-                              s: WatchState,
-                              events: ArrayBlockingQueue[Event],
-                              logger: Logger): Looper with HasWatchState = {
-    var recentEvents = Map.empty[Path, Deadline]
-    var registered = s.registered
-    var count = s.count
-    val lock = new Object
-    new Looper(s"watch-state-event-thread-${eventThreadId.incrementAndGet()}") with HasWatchState {
-      def incrementCount(): Unit = lock.synchronized { count += 1 }
-      def state(): WatchState = lock.synchronized(s.withCount(count).withRegistered(registered))
-      override def loop(): Unit = {
-        recentEvents = recentEvents.filterNot(_._2.isOverdue)
-        getFilesForKey(s.service.poll(delay)).foreach(maybeTrigger)
-      }
-      def getFilesForKey(key: WatchKey): Vector[Path] = key match {
-        case null => Vector.empty
-        case k =>
-          val rawEvents = k.synchronized {
-            val events = k.pollEvents.asScala.toVector
-            k.reset()
-            events
-          }
-          val keyPath = k.watchable.asInstanceOf[Path]
-          val allEvents = rawEvents.flatMap {
-            case e if e.kind.equals(OVERFLOW) =>
-              handleOverflow(k)
-            case e if !e.kind.equals(OVERFLOW) && e.context != null =>
-              Some(keyPath.resolve(e.context.asInstanceOf[Path]))
-            case _ => None
-          }
-          logger.debug(s"Received events:\n${allEvents.mkString("\n")}")
-          val (exist, notExist) = allEvents.partition(Files.exists(_))
-          val (updatedDirectories, updatedFiles) = exist.partition(Files.isDirectory(_))
-          val newFiles = updatedDirectories.flatMap(filesForNewDirectory)
-          lock.synchronized { registered --= notExist }
-          notExist.foreach(s.unregister)
-          updatedFiles ++ newFiles ++ notExist
+  private[EventMonitor] def applyImpl(watchState: WatchState,
+                                      delay: FiniteDuration,
+                                      antiEntropy: FiniteDuration,
+                                      terminationCondition: => Boolean,
+                                      logger: Logger,
+                                      closeService: Boolean): EventMonitor = {
+    val eventLogger = new io.Logger {
+      override def debug(msg: => Any): Unit = logger.debug(msg)
+    }
+    val observable = new WatchServiceBackedObservable[Path](watchState,
+                                                            delay,
+                                                            (_: TypedPath).getPath,
+                                                            closeService,
+                                                            eventLogger)
+    val monitor = FileEventMonitor.antiEntropy(observable, antiEntropy, eventLogger)
+    new EventMonitor {
+      private[this] var count = watchState.count
+
+      /** Block indefinitely until the monitor receives a file event or the user stops the watch. */
+      @tailrec
+      override final def awaitEvent(): Boolean = {
+        val triggeredPath = monitor
+          .poll(10.millis)
+          .find(p => watchState.sources.exists(s => s.accept(p.entry.typedPath.getPath)))
+        triggeredPath match {
+          case Some(p) =>
+            logger.debug(s"Triggered by ${p.entry.typedPath.getPath}")
+            count += 1
+            true
+          case _ if terminationCondition => false
+          case _                         => awaitEvent()
+        }
       }
 
-      /*
-       * In the case of an overflow, we must poll the file system to find out if there are added
-       * or removed directories. When there are new directories, we also want to return file
-       * events for the files that are found therein. Because an overflow is likely to occur while
-       * a directory is still being modified, we poll repeatedly until we get the same list of
-       * files consecutively. We will not trigger for any files that are updated while the WatchKey
-       * is in the OVERFLOW state. There is no good way to fix this without caching mtimes for
-       * all of the files, which I don't think is worth doing at this juncture.
-       */
-      private def handleOverflow(key: WatchKey): Vector[Path] = lock.synchronized {
-        val allFiles = new mutable.HashSet[Path]
-        def addNewFiles(): Unit = {
-          allFiles.clear()
-          val path = key.watchable.asInstanceOf[Path]
-          Files.walkFileTree(
-            path,
-            new FileVisitor[Path] {
-              override def preVisitDirectory(dir: Path,
-                                             attrs: BasicFileAttributes): FileVisitResult = {
-                allFiles += dir
-                if (!registered.contains(dir)) registered += dir -> s.register(dir)
-                FileVisitResult.CONTINUE
-              }
-              override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
-                allFiles += file
-                FileVisitResult.CONTINUE
-              }
-              override def visitFileFailed(file: Path, exc: IOException): FileVisitResult =
-                FileVisitResult.SKIP_SUBTREE
-              override def postVisitDirectory(dir: Path, exc: IOException): FileVisitResult =
-                FileVisitResult.CONTINUE
-            }
-          )
-          ()
-        }
+      /** A snapshot of the WatchState that includes the number of build triggers and watch sources. */
+      override def state(): WatchState = watchState.withCount(count)
 
-        var oldFiles = mutable.Set.empty[Path]
-        do {
-          oldFiles = allFiles
-          addNewFiles()
-        } while (oldFiles != allFiles)
-        registered --= registered.collect {
-          case (d, k) if !Files.exists(d) =>
-            k.reset()
-            k.cancel()
-            d
-        }
-        allFiles.toVector
-      }
-
-      /*
-       * Returns new files found in new directory and any subdirectories, assuming that there is
-       * a recursive source with a base that is parent to the directory.
-       */
-      private def filesForNewDirectory(dir: Path): Iterator[Path] = {
-        lazy val recursive =
-          s.sources.exists(src => dir.startsWith(src.base.toPath) && src.recursive)
-        if (!registered.contains(dir) && recursive) {
-          val dirs = Files.walk(dir).iterator.asScala.filter(Files.isDirectory(_))
-          val newDirs = dirs.map(d => d -> s.register(d)).toIndexedSeq
-          lock.synchronized { registered ++= newDirs }
-          Files.walk(dir).iterator.asScala
-        } else Nil.iterator
-      }
-      /*
-       * Triggers only if there is no pending Trigger and the file is not in an anti-entropy
-       * quarantine.
-       */
-      private def maybeTrigger(path: Path): Unit =
-        if (s.accept(path)) {
-          if (recentEvents.get(path).fold(false)(!_.isOverdue))
-            logger.debug(s"Ignoring watch event for $path due to anti-entropy constraint")
-          else
-            events.peek() match {
-              case Cancelled =>
-                logger.debug(s"Watch cancelled, not offering event for path $path")
-              case _ =>
-                recentEvents += path -> antiEntropy.fromNow
-                if (!events.offer(Triggered(path))) {
-                  logger.debug(s"Event already pending, dropping event for path: $path")
-                }
-            }
-        }
+      override def close(): Unit = monitor.close()
     }
   }
+
   // Shutup the compiler about unused arguments
   @inline private[this] def ignoreArg(arg: => Any): Unit = if (true) () else { arg; () }
   trait Logger {
     def debug(msg: => Any): Unit = ignoreArg(msg)
   }
-  object NullLogger extends Logger
-  private def newUserInputThread(terminationCondition: => Boolean,
-                                 events: ArrayBlockingQueue[Event],
-                                 logger: Logger): Looper =
-    new Looper(s"watch-state-user-input-${userInputId.incrementAndGet}") {
-      override final def loop(): Unit = {
-        Thread.sleep(10)
-        if (terminationCondition) {
-          logger.debug("Received termination condition. Stopping watch...")
-          events.peek match {
-            case Cancelled =>
-            case _ =>
-              while (!events.offer(Cancelled)) {
-                events.clear()
-              }
-          }
-        } else {}
-      }
-    }
-
-  private abstract class Looper(name: String) extends Thread(name) with AutoCloseable {
-    private[this] var stopped = false
-    private[this] var started = false
-    private[this] val lock = new Object()
-    def isStopped: Boolean = this.synchronized(stopped)
-    def loop(): Unit
-    @tailrec
-    private final def runImpl(firstTime: Boolean): Unit = {
-      if (firstTime) {
-        started = true
-        lock.synchronized(lock.notifyAll)
-      }
-      try {
-        if (!isStopped) {
-          loop()
-        }
-      } catch {
-        case (_: ClosedWatchServiceException | _: InterruptedException) =>
-          this.synchronized { stopped = true }
-      }
-      if (!isStopped) {
-        runImpl(firstTime = false)
-      }
-    }
-    override final def run(): Unit = runImpl(firstTime = true)
-    def close(): Unit = this.synchronized {
-      if (!stopped) {
-        stopped = true
-        this.interrupt()
-        this.join(5000)
-      }
-    }
-    setDaemon(true)
-    start()
-    lock.synchronized { if (!started) lock.wait() }
+  object NullLogger extends Logger {
+    override def debug(msg: => Any): Unit = ignoreArg(msg)
   }
-  private val eventThreadId = new AtomicInteger(0)
-  private val userInputId = new AtomicInteger(0)
-
 }

--- a/io/src/main/scala/sbt/internal/io/EventMonitor.scala
+++ b/io/src/main/scala/sbt/internal/io/EventMonitor.scala
@@ -21,6 +21,7 @@ import scala.concurrent.duration._
  *
  * No implementation details are specified so that the EventMonitor may be treated as a black box.
  */
+@deprecated("This has been removed in favor of FileEventMonitor", "1.3.0")
 private[sbt] sealed trait EventMonitor extends AutoCloseable {
 
   /** Block indefinitely until the monitor receives a file event or the user stops the watch. */
@@ -46,6 +47,9 @@ private[sbt] object EventMonitor {
    * @param logger               Logs output
    * @return The new EventMonitor
    */
+  @deprecated("This method is no longer used in sbt. It exists for legacy binary compatibility " +
+                "within the 1.x series.",
+              "1.3.0")
   def apply(watchState: WatchState,
             delay: FiniteDuration,
             antiEntropy: FiniteDuration,

--- a/io/src/main/scala/sbt/internal/io/FileRepositoryImpl.scala
+++ b/io/src/main/scala/sbt/internal/io/FileRepositoryImpl.scala
@@ -1,0 +1,47 @@
+package sbt.internal.io
+
+import java.io.IOException
+import java.nio.file.{ Path => JPath }
+
+import com.swoval.files.FileTreeDataViews.Converter
+import com.swoval.files.{ FileTreeRepositories, TypedPath => STypedPath }
+import com.swoval.functional.Filters
+import sbt.internal.io.SwovalConverters.{ SwovalEitherOps, SwovalEntryOps, ObserverOps }
+import sbt.io.{ FileRepository, FileTreeDataView, TypedPath }
+import FileTreeDataView.Entry
+
+import scala.collection.immutable.VectorBuilder
+
+/**
+ * The default implemenation of [[FileRepository]]. It delegates all of its methods to the
+ * [[https://swoval.github.io/files/jvm/com/swoval/files/FileTreeRepository.html swoval FileTreeRepository]].
+ * @param converter the function to convert paths to
+ * @tparam T the type of the [[FileTreeDataView.Entry.value]]s.
+ */
+private[sbt] class FileRepositoryImpl[+T](converter: TypedPath => T) extends FileRepository[T] {
+  private[this] val underlying = FileTreeRepositories.get[T](new Converter[T] {
+    import SwovalConverters.SwovalTypedPathOps
+    override def apply(path: STypedPath): T = converter(path.asSbt)
+  }, true)
+
+  override def addObserver(observer: FileTreeDataView.Observer[T]): Int =
+    underlying.addCacheObserver(observer.asSwoval)
+  override def list(path: JPath, maxDepth: Int, filter: TypedPath => Boolean): Seq[TypedPath] =
+    listEntries(path, maxDepth, (e: Entry[T]) => filter(e.typedPath)).map(_.typedPath)
+  override def listEntries(path: JPath,
+                           maxDepth: Int,
+                           filter: Entry[T] => Boolean): Seq[Entry[T]] = {
+    val res = new VectorBuilder[Entry[T]]
+    val it = underlying.listEntries(path, maxDepth, Filters.AllPass).iterator
+    while (it.hasNext) {
+      val entry: Entry[T] = it.next.asSbt
+      if (filter(entry)) res += entry
+    }
+    res.result
+  }
+  override def register(path: JPath, maxDepth: Int): Either[IOException, Boolean] =
+    underlying.register(path, maxDepth).asScala
+  override def removeObserver(handle: Int): Unit = underlying.removeObserver(handle)
+  override def unregister(path: JPath): Unit = underlying.unregister(path)
+  override def close(): Unit = underlying.close()
+}

--- a/io/src/main/scala/sbt/internal/io/HybridPollingFileRepository.scala
+++ b/io/src/main/scala/sbt/internal/io/HybridPollingFileRepository.scala
@@ -1,0 +1,113 @@
+package sbt.internal.io
+
+import java.io.IOException
+import java.nio.file.Path
+
+import sbt.io.FileTreeDataView.{ Entry, Observable }
+import sbt.io._
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+ * A hybrid [[FileRepository]] that caches some paths and monitors them with os notifications and
+ * does not cache the paths that are filtered using the provided shouldPoll function. As a general
+ * rule, the paths to be polled should ideally not be in the same directory tree as any of the
+ * paths that are being cached. The [[FileRepository.list]] method should do the right thing in this
+ * case, but it's possible that there may be some bugs in handling the overlapping paths.
+ *
+ * @tparam T the type of the [[Entry.value]]s.
+ */
+private[sbt] trait HybridPollingFileRepository[+T] extends FileRepository[T] { self =>
+  def shouldPoll(path: Path): Boolean
+  def shouldPoll(typedPath: TypedPath): Boolean = shouldPoll(typedPath.getPath)
+  def shouldPoll(source: Source): Boolean = shouldPoll(source.base.toPath)
+  def toPollingObservable(delay: FiniteDuration,
+                          sources: Seq[Source],
+                          logger: Logger): Observable[T]
+}
+
+private[io] case class HybridPollingFileRepositoryImpl[+T](converter: TypedPath => T,
+                                                           pollingSources: Seq[Source])
+    extends HybridPollingFileRepository[T] { self =>
+  private val repo = new FileRepositoryImpl[T](converter)
+  private val view = DefaultFileTreeView.asDataView(converter)
+  private val shouldPollEntry: Entry[_] => Boolean = (e: Entry[_]) => shouldPoll(e.typedPath)
+
+  override def shouldPoll(path: Path): Boolean = pollingSources.exists(_.accept(path))
+  override def addObserver(observer: FileTreeDataView.Observer[T]): Int =
+    repo.addObserver(observer)
+  override def register(path: Path, maxDepth: Int): Either[IOException, Boolean] = {
+    if (shouldPoll(path)) Right(false) else repo.register(path, maxDepth)
+  }
+  override def removeObserver(handle: Int): Unit = repo.removeObserver(handle)
+  override def listEntries(path: Path,
+                           maxDepth: Int,
+                           filter: Entry[T] => Boolean): Seq[FileTreeDataView.Entry[T]] = {
+    if (!shouldPoll(path)) {
+      /*
+       * The repository may contain some paths that require polling to access. We must remove
+       * those entries from the result. For every one of these entries that is a directory, we
+       * must poll that directory and add its result to the list. If the entry is a regular file,
+       * then we need to poll just that file.
+       */
+      val (needPoll, ready) =
+        repo
+          .listEntries(path, maxDepth, (e: Entry[T]) => filter(e) || shouldPollEntry(e))
+          .partition(shouldPollEntry)
+      ready ++ needPoll.flatMap {
+        case e @ Entry(typedPath, _) if typedPath.isDirectory =>
+          val path = typedPath.getPath
+          val depth =
+            if (maxDepth == Integer.MAX_VALUE) Integer.MAX_VALUE
+            else maxDepth - path.relativize(path).getNameCount - 1
+          Some(e).filter(filter) ++
+            view.listEntries(path, depth, (e: Entry[T]) => shouldPollEntry(e) && filter(e))
+        case Entry(typedPath, _)
+            if shouldPoll(typedPath) && !shouldPoll(typedPath.getPath.getParent) =>
+          view.listEntries(typedPath.getPath, -1, (_: Entry[T]) => true)
+        case _ =>
+          Nil
+      }
+    } else {
+      view.listEntries(path, maxDepth, (e: Entry[T]) => shouldPollEntry(e) && filter(e))
+    }
+  }
+  override def list(path: Path, maxDepth: Int, filter: TypedPath => Boolean): Seq[TypedPath] =
+    listEntries(path, maxDepth, (e: Entry[T]) => filter(e.typedPath)).map(_.typedPath)
+
+  override def unregister(path: Path): Unit = repo.unregister(path)
+  override def close(): Unit = {
+    repo.close()
+  }
+  def toPollingObservable(delay: FiniteDuration,
+                          sources: Seq[Source],
+                          logger: Logger): Observable[T] = {
+    val pollingSources = sources.filter(shouldPoll)
+    if (pollingSources.isEmpty) self
+    else {
+      new Observable[T] {
+        private val observers = new Observers[T]
+        private val handle = self.addObserver(observers)
+        private val watchState = WatchState.empty(new PollingWatchService(delay), pollingSources)
+        private val observable =
+          new WatchServiceBackedObservable[T](watchState, delay, converter, true, logger)
+        observable.addObserver(observers)
+
+        override def addObserver(observer: FileTreeDataView.Observer[T]): Int =
+          observers.addObserver(observer)
+
+        override def removeObserver(handle: Int): Unit = observers.removeObserver(handle)
+
+        override def close(): Unit = {
+          observable.close()
+          self.removeObserver(handle)
+        }
+      }
+    }
+  }
+}
+
+private[sbt] object HybridPollingFileRepository {
+  def apply[T](converter: TypedPath => T, pollingSources: Source*): HybridPollingFileRepository[T] =
+    HybridPollingFileRepositoryImpl(converter, pollingSources)
+}

--- a/io/src/main/scala/sbt/internal/io/Observers.scala
+++ b/io/src/main/scala/sbt/internal/io/Observers.scala
@@ -1,0 +1,39 @@
+package sbt.internal.io
+import java.util
+import java.util.concurrent.atomic.AtomicInteger
+
+import sbt.io.FileTreeDataView.{ Entry, Observable, Observer }
+
+import scala.collection.mutable
+import scala.collection.JavaConverters._
+
+private[io] class Observers[T] extends Observer[T] with Observable[T] {
+  private[this] val id = new AtomicInteger(0)
+  private[this] val observers: mutable.Map[Int, Observer[T]] =
+    new util.LinkedHashMap[Int, Observer[T]]().asScala
+
+  override def onCreate(newEntry: Entry[T]): Unit = observers.synchronized {
+    observers.values.foreach(_.onCreate(newEntry))
+  }
+
+  override def onDelete(oldEntry: Entry[T]): Unit = observers.synchronized {
+    observers.values.foreach(_.onDelete(oldEntry))
+  }
+
+  override def onUpdate(oldEntry: Entry[T], newEntry: Entry[T]): Unit = observers.synchronized {
+    observers.values.foreach(_.onUpdate(oldEntry, newEntry))
+  }
+
+  override def addObserver(observer: Observer[T]) = observers.synchronized {
+    val observerId = id.incrementAndGet()
+    observers += observerId -> observer
+    observerId
+  }
+
+  override def removeObserver(handle: Int): Unit = observers.synchronized {
+    observers -= handle
+    ()
+  }
+
+  override def close(): Unit = observers.synchronized(observers.clear())
+}

--- a/io/src/main/scala/sbt/internal/io/SourceModificationWatch.scala
+++ b/io/src/main/scala/sbt/internal/io/SourceModificationWatch.scala
@@ -11,6 +11,7 @@ import sbt.io._
 import sbt.io.syntax._
 
 import scala.collection.JavaConverters._
+import scala.collection.immutable
 import scala.concurrent.duration._
 
 private[sbt] object SourceModificationWatch {
@@ -189,4 +190,14 @@ private[sbt] object WatchState {
     initState
   }
 
+  def empty(sources: Seq[Source]): WatchState = {
+    val service = new WatchService {
+      override def init(): Unit = {}
+      override def pollEvents(): Map[WatchKey, immutable.Seq[WatchEvent[Path]]] = Map.empty
+      override def poll(timeout: Duration): WatchKey = null
+      override def register(path: Path, events: WatchEvent.Kind[Path]*): WatchKey = null
+      override def close(): Unit = {}
+    }
+    new WatchState(count = 1, sources, service, Map.empty)
+  }
 }

--- a/io/src/main/scala/sbt/internal/io/SwovalConverters.scala
+++ b/io/src/main/scala/sbt/internal/io/SwovalConverters.scala
@@ -1,0 +1,49 @@
+package sbt.internal.io
+
+import java.io.IOException
+import java.nio.file.{ Path => JPath }
+
+import com.swoval.files.FileTreeDataViews.{ CacheObserver, Entry => SEntry }
+import com.swoval.files.{ TypedPath => STypedPath }
+import com.swoval.functional.{ Either => SEither }
+import sbt.io.FileTreeDataView.{ Entry, Observer }
+import sbt.io.TypedPath
+
+/**
+ * Utilities for converting between swoval and sbt data types.
+ */
+private[io] object SwovalConverters {
+  implicit class SwovalTypedPathOps(val typedPath: STypedPath) extends AnyVal {
+    def asSbt: TypedPath = new TypedPath {
+      override def getPath: JPath = typedPath.getPath
+      override def exists: Boolean = typedPath.exists()
+      override def isDirectory: Boolean = typedPath.isDirectory
+      override def isFile: Boolean = typedPath.isFile
+      override def isSymbolicLink: Boolean = typedPath.isSymbolicLink
+      override def toString: String = s"TypedPath($getPath)"
+    }
+  }
+
+  implicit class SwovalEntryOps[T](val entry: SEntry[T]) extends AnyVal {
+    def asSbt: Entry[T] = Entry(entry.getTypedPath.asSbt, entry.getValue.asScala)
+  }
+
+  implicit class SwovalEitherOps[L, R](val either: SEither[L, R]) extends AnyVal {
+    def asScala[R0](implicit f: R => R0): Either[L, R0] = either match {
+      case l: com.swoval.functional.Either.Left[L, R] =>
+        Left(com.swoval.functional.Either.leftProjection(l).getValue)
+      case r: com.swoval.functional.Either.Right[L, R] => Right(f(r.get()))
+    }
+  }
+
+  private class DelegateCacheObserver[T](observer: Observer[T]) extends CacheObserver[T] {
+    override def onCreate(newEntry: SEntry[T]): Unit = observer.onCreate(newEntry.asSbt)
+    override def onDelete(oldEntry: SEntry[T]): Unit = observer.onDelete(oldEntry.asSbt)
+    override def onUpdate(oldEntry: SEntry[T], newEntry: SEntry[T]): Unit =
+      observer.onUpdate(oldEntry.asSbt, newEntry.asSbt)
+    override def onError(exception: IOException): Unit = {}
+  }
+  implicit class ObserverOps[T](val observer: Observer[T]) extends AnyVal {
+    def asSwoval: CacheObserver[T] = new DelegateCacheObserver[T](observer)
+  }
+}

--- a/io/src/main/scala/sbt/internal/io/WatchServiceBackedObservable.scala
+++ b/io/src/main/scala/sbt/internal/io/WatchServiceBackedObservable.scala
@@ -1,0 +1,162 @@
+package sbt.internal.io
+
+import java.nio.file.StandardWatchEventKinds.OVERFLOW
+import java.nio.file.{ Files, Path, WatchKey }
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger }
+import java.util.concurrent.{ CountDownLatch, TimeUnit }
+
+import sbt.io.FileTreeDataView.{ Entry, Observable }
+import sbt.io.FileTreeView.AllPass
+import sbt.io.{ FileTreeDataView, FileTreeView, Logger, TypedPath }
+
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.concurrent.duration._
+
+object WatchServiceBackedObservable {
+  private val eventThreadId = new AtomicInteger(0)
+}
+import sbt.internal.io.WatchServiceBackedObservable._
+private[sbt] class WatchServiceBackedObservable[+T](s: WatchState,
+                                                    delay: FiniteDuration,
+                                                    converter: TypedPath => T,
+                                                    closeService: Boolean,
+                                                    logger: Logger)
+    extends Observable[T] {
+  private[this] val closed = new AtomicBoolean(false)
+  private[this] val observers = new Observers[T]
+  private[this] val thread: Thread = {
+    val entryConverter = Entry.converter(converter)
+    var registered = s.registered
+    val lock = new Object
+    val latch = new CountDownLatch(1)
+    new Thread(s"watch-state-event-thread-${eventThreadId.incrementAndGet()}") {
+      setDaemon(true)
+      start()
+      if (!latch.await(5, TimeUnit.SECONDS))
+        throw new IllegalStateException("Couldn't start event thread")
+      @tailrec
+      final def loopImpl(): Unit = {
+        if (!closed.get) getFilesForKey(s.service.poll(delay)).foreach { entry =>
+          if (entry.typedPath.exists) observers.onCreate(entry) else observers.onDelete(entry)
+        }
+        if (!closed.get) loopImpl()
+      }
+      override def run(): Unit = {
+        latch.countDown()
+        try {
+          loopImpl()
+        } catch {
+          case _: InterruptedException =>
+        }
+      }
+
+      def getFilesForKey(key: WatchKey): Vector[Entry[T]] = key match {
+        case null => Vector.empty
+        case k =>
+          val rawEvents = k.synchronized {
+            val events = k.pollEvents.asScala.toVector
+            k.reset()
+            events
+          }
+          val keyPath = k.watchable.asInstanceOf[Path]
+          val allEvents = rawEvents.flatMap {
+            case e if e.kind.equals(OVERFLOW) =>
+              handleOverflow(k)
+            case e if !e.kind.equals(OVERFLOW) && e.context != null =>
+              Some(TypedPath(keyPath.resolve(e.context.asInstanceOf[Path])))
+            case _ => None
+          }
+          logger.debug(s"Received events:\n${allEvents.mkString("\n")}")
+          val (exist, notExist) = allEvents.partition(_.exists)
+          val (updatedDirectories, updatedFiles) = exist.partition(_.isDirectory)
+          val newFiles = updatedDirectories.flatMap(filesForNewDirectory)
+          lock.synchronized { registered --= notExist.map(_.getPath) }
+          notExist.foreach(p => s.unregister(p.getPath))
+          (updatedDirectories ++ updatedFiles ++ newFiles ++ notExist).map(tp =>
+            Entry(tp, entryConverter))
+      }
+
+      /*
+       * In the case of an overflow, we must poll the file system to find out if there are added
+       * or removed directories. When there are new directories, we also want to return file
+       * events for the files that are found therein. Because an overflow is likely to occur while
+       * a directory is still being modified, we poll repeatedly until we get the same list of
+       * files consecutively. We will not trigger for any files that are updated while the WatchKey
+       * is in the OVERFLOW state. There is no good way to fix this without caching mtimes for
+       * all of the files, which I don't think is worth doing at this juncture.
+       */
+      private def handleOverflow(key: WatchKey): Vector[TypedPath] = lock.synchronized {
+        val allFiles = new mutable.HashSet[TypedPath]
+        def addNewFiles(): Unit = {
+          allFiles.clear()
+          val path = key.watchable.asInstanceOf[Path]
+          val view = FileTreeView.DEFAULT
+          view.list(path, maxDepth = Integer.MAX_VALUE, AllPass).foreach { typedPath =>
+            allFiles += typedPath
+            val path = typedPath.getPath
+            if (typedPath.isDirectory && !registered.contains(path)) {
+              registered += path -> s.register(path)
+            }
+          }
+          ()
+        }
+
+        var oldFiles = mutable.Set.empty[TypedPath]
+        do {
+          oldFiles = allFiles
+          addNewFiles()
+        } while (oldFiles != allFiles)
+        registered --= registered.collect {
+          case (d, k) if !Files.exists(d) =>
+            k.reset()
+            k.cancel()
+            d
+        }
+        allFiles.toVector
+      }
+
+      /*
+       * Returns new files found in new directory and any subdirectories, assuming that there is
+       * a recursive source with a base that is parent to the directory.
+       */
+      private def filesForNewDirectory(typedPath: TypedPath): Seq[TypedPath] =
+        if (!closed.get()) {
+          val dir = typedPath.getPath
+          lazy val recursive =
+            s.sources.exists(src => dir.startsWith(src.base.toPath) && src.recursive)
+          if (!registered.contains(dir) && recursive) {
+            registered += dir -> s.register(dir)
+            @tailrec
+            def poll(paths: Seq[Path] = Nil): Seq[TypedPath] = {
+              val typedPaths = FileTreeView.DEFAULT.list(dir, maxDepth = Integer.MAX_VALUE, AllPass)
+              val newPaths = typedPaths.map(_.getPath)
+              if (newPaths == paths) typedPaths else poll(newPaths)
+            }
+            val result = poll()
+            val newDirs = result.collect {
+              case tp if tp.isDirectory && !closed.get() => tp.getPath -> s.register(tp.getPath)
+            }
+            lock.synchronized { registered ++= newDirs }
+            result.toVector
+          } else Nil
+        } else Nil
+    }
+  }
+  override def addObserver(observer: FileTreeDataView.Observer[T]): Int =
+    observers.addObserver(observer)
+
+  override def removeObserver(handle: Int): Unit = {
+    observers.removeObserver(handle)
+    ()
+  }
+  override def close(): Unit = {
+    if (closed.compareAndSet(false, true)) {
+      thread.interrupt()
+      thread.join(5.seconds.toMillis)
+      if (closeService) s.close()
+      logger.debug("Closed WatchServiceBackedObservable")
+    }
+  }
+}

--- a/io/src/main/scala/sbt/io/FileEventMonitor.scala
+++ b/io/src/main/scala/sbt/io/FileEventMonitor.scala
@@ -1,0 +1,241 @@
+package sbt.io
+
+import java.nio.file.{ Path => JPath }
+import java.util.concurrent.{ ArrayBlockingQueue, ConcurrentHashMap, TimeUnit }
+
+import sbt.io.FileTreeDataView.{ Entry, Observable, Observer }
+
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.concurrent.duration._
+
+/**
+ * Provides a blocking interface for awaiting events from an [[FileTreeDataView.Observable]].
+ * @tparam T the type of [[FileTreeDataView.Entry.value]] instances
+ */
+trait FileEventMonitor[+T] extends AutoCloseable {
+
+  /**
+   * Block for the specified duration until an event is emitted or a timeout occurs.
+   * @param duration the timeout (can be infinite)
+   * @return a sequence of [[FileEventMonitor.Event]] instances.
+   */
+  def poll(duration: Duration): Seq[FileEventMonitor.Event[T]]
+}
+object FileEventMonitor {
+  sealed trait Event[+T] {
+    def entry: Entry[T]
+    def occurredAt: Deadline
+  }
+  object Event {
+    def unapply[T](event: Event[T]): Option[(Entry[T], Deadline)] =
+      Some((event.entry, event.occurredAt))
+  }
+
+  final case class Creation[+T](override val entry: Entry[T],
+                                override val occurredAt: Deadline = Deadline.now)
+      extends Event[T] {
+    override def equals(o: Any): Boolean = o match {
+      case Creation(e, _) => this.entry == e
+      case _              => false
+    }
+    override def hashCode(): Int = entry.hashCode()
+  }
+
+  final case class Update[+T](previous: Entry[T],
+                              entry: Entry[T],
+                              occurredAt: Deadline = Deadline.now)
+      extends Event[T] {
+    override def equals(o: Any): Boolean = o match {
+      case Update(prev, e, _) =>
+        this.previous == prev && this.entry == e
+      case _ => false
+    }
+    override def hashCode(): Int = previous.hashCode() ^ entry.hashCode()
+  }
+
+  final case class Deletion[+T](entry: Entry[T], occurredAt: Deadline = Deadline.now)
+      extends Event[T] {
+    override def equals(o: Any): Boolean = o match {
+      case Deletion(e, _) => this.entry == e
+      case _              => false
+    }
+    override def hashCode(): Int = entry.hashCode()
+  }
+
+  def apply[T](observable: Observable[T], logger: Logger = NullLogger): FileEventMonitor[T] =
+    new FileEventMonitorImpl[T](observable, logger)
+  def antiEntropy[T](observable: Observable[T],
+                     period: FiniteDuration,
+                     logger: Logger,
+                     quarantinePeriod: FiniteDuration = 50.millis): FileEventMonitor[T] = {
+    new AntiEntropyFileEventMonitor(period,
+                                    new FileEventMonitorImpl[T](observable, logger),
+                                    logger,
+                                    quarantinePeriod)
+  }
+
+  private class FileEventMonitorImpl[T](observable: Observable[T], logger: Logger)
+      extends FileEventMonitor[T] {
+    private case object Trigger
+    private val events =
+      new ConcurrentHashMap[JPath, FileEventMonitor.Event[T]]().asScala
+    private val queue = new ArrayBlockingQueue[Trigger.type](1)
+    private val lock = new Object
+    /*
+     * This method will coalesce the new event with a possibly existing previous event. The aim is
+     * that whenever the user calls poll, they will get the final difference between the previous
+     * state of the file system and the new state, but without the incremental changes that may
+     * have occurred along the way.
+     */
+    private def add(event: Event[T]): Unit = {
+      def put(path: JPath, event: FileEventMonitor.Event[T]): Unit = lock.synchronized {
+        events.put(path, event)
+        queue.offer(Trigger)
+        ()
+      }
+      logger.debug(s"Received $event")
+      val path = event.entry.typedPath.getPath
+      lock.synchronized(events.putIfAbsent(path, event)) match {
+        case Some(d: Deletion[T]) =>
+          event match {
+            case _: Deletion[T] =>
+            case Update(previous, _, _) =>
+              put(path, Deletion(previous, event.occurredAt))
+            case _ => put(path, Update(d.entry, event.entry, event.occurredAt))
+          }
+        case Some(_: Creation[T]) =>
+          event match {
+            case _: Deletion[T] => events.remove(path)
+            case _: Update[T]   => put(path, new Creation(event.entry, event.occurredAt))
+            case _              => put(path, event)
+          }
+        case Some(Update(previous, _, ts)) =>
+          event match {
+            case _: Deletion[T] => put(path, Deletion(previous, ts))
+            case e              => put(path, Update(previous, e.entry, ts))
+          }
+        case None =>
+          lock.synchronized(queue.offer(Trigger))
+      }
+      ()
+    }
+    private val handle = observable.addObserver(
+      Observer(
+        (entry: Entry[T]) => add(Creation(entry)),
+        (entry: Entry[T]) => add(Deletion(entry)),
+        (previous: Entry[T], current: Entry[T]) => add(Update(previous, current))
+      ))
+
+    @tailrec
+    final override def poll(duration: Duration): Seq[FileEventMonitor.Event[T]] = {
+      val start = Deadline.now
+      if (lock.synchronized(events.isEmpty) && duration > 0.seconds) {
+        duration match {
+          case d: FiniteDuration => queue.poll(d.toNanos, TimeUnit.NANOSECONDS)
+          case _                 => queue.take()
+        }
+      }
+      val res = lock.synchronized {
+        queue.poll(0, TimeUnit.MILLISECONDS)
+        val r = events.values.toVector
+        events.clear()
+        r
+      }
+      res match {
+        case e if e.isEmpty =>
+          val now = Deadline.now
+          duration match {
+            case d: FiniteDuration => if (now < start + d) poll((start + d) - now) else Nil
+            case _                 => poll(duration)
+          }
+        case e => e
+      }
+    }
+
+    override def close(): Unit = {
+      observable.removeObserver(handle)
+      events.clear()
+      observable.close()
+    }
+  }
+  private class AntiEntropyFileEventMonitor[T](period: FiniteDuration,
+                                               fileEventMonitor: FileEventMonitor[T],
+                                               logger: Logger,
+                                               quarantinePeriod: FiniteDuration)
+      extends FileEventMonitor[T] {
+    private[this] val recentEvents = mutable.Map.empty[JPath, Deadline]
+    /*
+     * It is very common for file writes to be implemented as a move, which manifests as a delete
+     * followed by a write. In sbt, this can manifest as continuous builds triggering for the delete
+     * and re-compiling before the replaced file is present. This is undesirable because deleting
+     * the file can break the build. Even if it doesn't break the build, it may cause the build to
+     * become inconsistent with the file system if the creation is dropped due to anti-entropy. To
+     * avoid this behavior, we quarantine the deletion and return immediately if a subsequent
+     * creation is detected. This provides a reasonable compromise between low latency and
+     * correctness.
+     */
+    private[this] val quarantinedEvents = mutable.Map.empty[JPath, Event[T]]
+    @tailrec
+    override final def poll(duration: Duration): Seq[Event[T]] = {
+      val start = Deadline.now
+      /*
+       * The impl is tail recursive to handle the case when we quarantine a deleted file or find
+       * an event for a path that is an anti-entropy quarantine. In these cases, if there are other
+       * events in the queue, we want to immediately pull them. Otherwise it's possible to return
+       * None while there events ready in the queue.
+       */
+      val results = fileEventMonitor.poll(duration)
+      /*
+       * Note that this transformation is not purely functional because it has the side effect of
+       * modifying the quarantinedEvents and recentEvents maps.
+       */
+      val transformed = results.flatMap {
+        case event @ Event(entry @ Entry(typedPath, _), occurredAt) =>
+          val path = typedPath.getPath
+          val quarantined = if (typedPath.exists) quarantinedEvents.remove(path) else None
+          quarantined match {
+            case Some(Deletion(deletedEntry, deletionTs)) =>
+              recentEvents.put(path, deletionTs + period)
+              logger.debug(
+                s"Triggering event for newly created path $path that was previously quarantined.")
+              Some(Update(deletedEntry, entry, deletionTs))
+            case _ =>
+              recentEvents.get(path) match {
+                case Some(deadline) if (deadline - occurredAt) < period =>
+                  logger.debug(s"Discarding entry for recently updated path $path")
+                  None
+                case _ if !typedPath.exists =>
+                  quarantinedEvents.put(path, event)
+                  logger.debug(s"Quarantining deletion event for path $path for $period")
+                  None
+                case _ =>
+                  recentEvents.put(path, occurredAt + period)
+                  logger.debug(s"Received event for path $path")
+                  Some(event)
+              }
+          }
+      } ++ quarantinedEvents.collect {
+        case (path, event @ Deletion(_, deadline)) if (deadline + quarantinePeriod).isOverdue =>
+          quarantinedEvents.remove(path)
+          recentEvents.put(path, deadline + period)
+          logger.debug(s"Triggering event for previously quarantined deleted file: $path")
+          event
+      }
+      recentEvents.retain((_, deadline) => !deadline.isOverdue)
+      transformed match {
+        case s if s.nonEmpty => s
+        case _ =>
+          val limit = duration - (Deadline.now - start)
+          if (limit > 0.millis) poll(limit) else Nil
+      }
+    }
+
+    override def close(): Unit = {
+      quarantinedEvents.clear()
+      recentEvents.clear()
+      fileEventMonitor.close()
+    }
+  }
+}

--- a/io/src/main/scala/sbt/io/FileRepository.scala
+++ b/io/src/main/scala/sbt/io/FileRepository.scala
@@ -5,7 +5,12 @@ import java.nio.file.LinkOption.NOFOLLOW_LINKS
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{ Files, NoSuchFileException, Path => JPath }
 
-import sbt.internal.io.{ DefaultFileTreeView, FileRepositoryImpl }
+import sbt.internal.io.{
+  DefaultFileTreeView,
+  FileRepositoryImpl,
+  HybridPollingFileRepository,
+  Source
+}
 import sbt.io.FileTreeDataView.{ Entry, Observable }
 
 /**
@@ -297,4 +302,16 @@ object FileRepository {
    */
   def default[T](converter: TypedPath => T): FileRepository[T] =
     new FileRepositoryImpl[T](converter)
+
+  /**
+   * Create a [[FileRepository]]. The generated repository will cache the file system tree for some
+   * of the paths under monitoring, but others will need to be polled.
+   * @param converter function to generate an [[FileTreeDataView.Entry.value]] from a [[TypedPath]]
+   * @param pollingSources do not cache any path contained in these [[sbt.internal.io.Source]]s.
+   * @tparam T the generic type of the [[FileTreeDataView.Entry.value]]
+   * @return a file repository.
+   */
+  def hybrid[T](converter: TypedPath => T,
+                pollingSources: Source*): HybridPollingFileRepository[T] =
+    HybridPollingFileRepository(converter, pollingSources: _*)
 }

--- a/io/src/main/scala/sbt/io/FileRepository.scala
+++ b/io/src/main/scala/sbt/io/FileRepository.scala
@@ -1,0 +1,227 @@
+package sbt.io
+
+import java.io.IOException
+import java.nio.file.{ Path => JPath }
+
+import sbt.io.FileTreeDataView.{ Entry, Observable }
+
+/**
+ * Represents a path in the file system. It may cache some of the file attributes so that no disk
+ * io is necessary to check, for example, whether the file is a directory or regular file.
+ */
+trait TypedPath {
+
+  /**
+   * The underlying path that this represents.
+   * @return the path
+   */
+  def getPath: JPath
+
+  /**
+   * Indicates whether or not the file exists. Because it may be cached, this method may not
+   * represent the current state of the file.
+   * @return true if the file exists
+   */
+  def exists: Boolean
+
+  /**
+   * Indicates whether or not the file is a directory. Because it may be cached, this method may not
+   * represent the current state of the file.
+   * @return true if the file is a directory
+   */
+  def isDirectory: Boolean
+
+  /**
+   * Indicates whether or not the file is a regular file. Because it may be cached, this method may not
+   * represent the current state of the file.
+   * @return true if the file is a regular file
+   */
+  def isFile: Boolean
+
+  /**
+   * Indicates whether or not the file is a symbolic link. Because it may be cached, this method may not
+   * represent the current state of the file.
+   * @return true if the file is a symbolic link
+   */
+  def isSymbolicLink: Boolean
+
+  override def toString: String = s"TypedPath($getPath)"
+}
+
+/**
+ * Provides a view into the file system that allows retrieval of the children of a particular path.
+ * Specific implementations may or may not use a cache for retrieval.
+ */
+trait FileTreeView extends AutoCloseable {
+
+  /**
+   * List the contents of the current directory.
+   *
+   * @param path      the path to list
+   * @param maxDepth  controls the depth of children of the path to include in the results. When
+   *                  maxDepth is -1, [[list]] should only return the TypedPath for this directory.
+   *                  For non-negative values, [[list]] should return only entries whose relativized
+   *                  path has {{{maxDepth - 1}}} elements. For example, when maxDepth is zero, all of
+   *                  the children of the path should be included in the result, but none of the
+   *                  children of any of the subdirectories should be included.
+   * @param filter    only return files accepted by the filter
+   * @return a sequence of [[TypedPath]]s.
+   */
+  def list(path: JPath, maxDepth: Int, filter: TypedPath => Boolean): Seq[TypedPath]
+}
+
+object FileTreeView {
+  object AllPass extends (Any => Boolean) {
+    override def apply(e: Any): Boolean = true
+  }
+}
+
+/**
+ * Provides a view into the file system that allows retrieval of the children of a particular path
+ * where each child has an associated [[FileTreeDataView.Entry]] that is generally derived from the
+ * file (e.g. the [[FileTreeDataView.Entry.value]] may be the md5 hash of the underlying file).
+ * Specific implementations may or may not use a cache for retrieval. It extends FileTreeView since
+ * [[FileTreeView.list]] can be trivially implemented using `listEntries`.
+ */
+trait FileTreeDataView[+T] extends FileTreeView with AutoCloseable {
+
+  /**
+   * List the contents of the current directory where each returned [[FileTreeDataView.Entry]] has a
+   * data value associated with it.
+   *
+   * @param path      the path to list
+   * @param maxDepth  controls the depth of children of the path to include in the results. When
+   *                  maxDepth is -1, [[listEntries]] should only return the TypedPath for this
+   *                  directory. For non-negative values, [[listEntries]] should return only
+   *                  entries whose relativized path has {{{maxDepth - 1}}} elements. For example,
+   *                  when maxDepth is zero, all of the children of the path should be included in
+   *                  the result, but none of the children of any of the subdirectories should be
+   *                  included.
+   * @param filter    only return files accepted by the filter
+   * @return a sequence of [[FileTreeDataView.Entry]] instances.
+   */
+  def listEntries(path: JPath, maxDepth: Int, filter: Entry[T] => Boolean): Seq[Entry[T]]
+}
+
+object FileTreeDataView {
+  abstract case class Entry[+T](path: JPath, value: Either[IOException, T]) extends TypedPath {
+    override def toString: String = s"Entry($path, $value)"
+  }
+
+  /**
+   * A FileRepository observer that receives callbacks
+   * @tparam T the generic type of [[Entry.value]] instances for the [[FileRepository]]
+   */
+  trait Observer[-T] {
+
+    /**
+     * Process a newly created entry
+     * @param newEntry the newly acceptcreate entry
+     */
+    def onCreate(newEntry: Entry[T]): Unit
+
+    /**
+     * Process a deleted entry
+     * @param oldEntry the deleted entry
+     */
+    def onDelete(oldEntry: Entry[T]): Unit
+
+    /**
+     * Process a deleted entry
+     * @param oldEntry the previous entry
+     * @param newEntry the current entry
+     */
+    /*
+     * Note that this interface exists for documentation purposes so that it is clear that the
+     * deleted entry is on the left. This would not be clear if filtering was handled with a
+     * `(Entry[T], Entry[T]) => Boolean`.
+     */
+    def onUpdate(oldEntry: Entry[T], newEntry: Entry[T]): Unit
+  }
+  object Observer {
+
+    /**
+     * Create a new Observer from callback functions.
+     *
+     * @param onCreate the callback to invoke when a new entry is created
+     * @param onDelete the callback to invoke when an entry is
+     * @param onUpdate the callback to invoke when an entry is updated. Note that the previous
+     *                 entry must be the first argument to this function.
+     * @tparam T the type of [[Entry.value]] instances for the [[Observable]]
+     * @return an [[Observer]] with the provided callbacks.
+     */
+    def apply[T](onCreate: Entry[T] => Unit,
+                 onDelete: Entry[T] => Unit,
+                 onUpdate: (Entry[T], Entry[T]) => Unit): Observer[T] =
+      new Impl(onCreate, onDelete, onUpdate)
+
+    private[FileTreeDataView] class Impl[-T](oncreate: Entry[T] => Unit,
+                                             ondelete: Entry[T] => Unit,
+                                             onupdate: (Entry[T], Entry[T]) => Unit)
+        extends Observer[T] {
+      override def onCreate(newEntry: Entry[T]): Unit = oncreate(newEntry)
+      override def onDelete(oldEntry: Entry[T]): Unit = ondelete(oldEntry)
+      override def onUpdate(oldEntry: Entry[T], newEntry: Entry[T]): Unit =
+        onupdate(oldEntry, newEntry)
+    }
+  }
+
+  /**
+   * An object that monitors a file system. The interface is very similar to that provided by other
+   * libraries/frameworks, such as [[http://reactivex.io/intro.html rxJava]]. When it detects changes
+   * in the file system, it will invoke a set of user specified callbacks. The Observable also
+   * allows the user to add and removes paths to monitor.
+   *
+   * @tparam T the generic type of [[Entry.value]] instances
+   */
+  trait Observable[+T] extends AutoCloseable {
+
+    /**
+     * Add callbacks to be invoked on file events.
+     *
+     * @param observer the callbacks to invoke
+     * @return a handle to the callback.
+     */
+    def addObserver(observer: Observer[T]): Int
+
+    /**
+     * Removes a callback that was added via [[addObserver]]
+     *
+     * @param handle The handle returned by [[addObserver]]
+     */
+    def removeObserver(handle: Int): Unit
+  }
+}
+
+/**
+ * Monitors registered directories for file changes. A typical implementation will keep an
+ * in memory cache of the file system that can be queried in [[FileRepository#listEntries]]. The
+ * [[FileRepository#register]] method adds monitoring for a particular cache. A filter may be provided
+ * so that the cache doesn't waste memory on files the user doesn't care about. The
+ * cache may be shared across a code base so there additional apis for adding filters or changing
+ * the recursive property of a directory.
+ *
+ * @tparam T the type of the [[FileTreeDataView.Entry.value]]s.
+ */
+trait FileRepository[+T] extends Observable[T] with FileTreeDataView[T] with AutoCloseable {
+
+  /**
+   * Register a directory for monitoring
+   *
+   * @param path     the path to list
+   * @param maxDepth controls how the depth of children of the registered path to consider. When
+   *                 maxDepth is -1, then the repository should only monitor the path itself. When
+   *                 it is zero, the the repository should monitor the path and its direct children.
+   *                 For values greater than zero,
+   * @return an Either that is a Right when register has no errors and a Left if an IOException is
+   *         thrown while registering the path. The result should be true if the path has
+   *         never been previously registered or if the recursive flag flips from false to true.
+   */
+  def register(path: JPath, maxDepth: Int): Either[IOException, Boolean]
+
+  /**
+   * Remove a path from monitoring.
+   * @param path the path to stop monitoring
+   */
+  def unregister(path: JPath): Unit
+}

--- a/io/src/main/scala/sbt/io/Logger.scala
+++ b/io/src/main/scala/sbt/io/Logger.scala
@@ -1,0 +1,9 @@
+package sbt.io
+
+private[sbt] trait Logger {
+  def debug(msg: => Any): Unit
+}
+private[sbt] object NullLogger extends Logger {
+  private def ignoreArg[T](f: => T): Unit = if (false) { f; () } else ()
+  override def debug(msg: => Any): Unit = ignoreArg(msg)
+}

--- a/io/src/main/scala/sbt/io/MacOSXWatchService.scala
+++ b/io/src/main/scala/sbt/io/MacOSXWatchService.scala
@@ -1,176 +1,46 @@
 package sbt.io
 
-import java.nio.file.StandardWatchEventKinds.{ ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY, OVERFLOW }
-import java.nio.file.{
-  ClosedWatchServiceException,
-  Files,
-  WatchEvent,
-  WatchKey,
-  Path => JPath,
-  Paths => JPaths
-}
-import java.util.concurrent._
-import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger }
-import java.util.{ Collections, List => JList }
-
-import com.swoval.concurrent.ThreadFactory
-import com.swoval.files.apple.FileEventsApi.Consumer
-import com.swoval.files.apple.{ FileEvent, FileEventsApi, Flags }
+import java.nio.file.{ WatchEvent, WatchKey, Path => JPath }
+import java.util.Collections
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.{ ConcurrentHashMap, TimeUnit }
 
 import scala.collection.JavaConverters._
 import scala.collection.{ immutable, mutable }
 import scala.concurrent.duration._
 
 class MacOSXWatchService extends WatchService with Unregisterable {
-  // The FsEvents api doesn't seem to report events at lower than 10 millisecond intervals.
-  private[this] val watchLatency: Duration = 10.milliseconds
-  private[this] val queueSize = 256
-
-  private[this] val executor =
-    Executors.newSingleThreadExecutor(new ThreadFactory("sbt.io.MacOSXWatchService"))
-  private[this] val streams = mutable.Set.empty[JPath]
-  private[this] def async[R](f: => R): Unit = {
-    executor.submit(new Runnable() { override def run(): Unit = { f; () } })
-    ()
-  }
-  private[this] val dropEvent = new Consumer[String] {
-    override def accept(s: String): Unit = async {
-      registered.synchronized {
-        val path = JPaths.get(s)
-        streams -= path
-        registered.get(path) match {
-          case None =>
-          case Some((k, _)) =>
-            registered += path -> (k -> -1)
-        }
-      }
-    }
-  }
-  private val onFileEvent = new Consumer[FileEvent] {
-    override def accept(fileEvent: FileEvent): Unit = async {
-      val path = JPaths.get(fileEvent.fileName)
-      registered.synchronized(registered.get(path) orElse registered.get(path.getParent) foreach {
-        case (key, _) =>
-          val exists = Files.exists(path)
-          if (exists && key.reportModifyEvents) createEvent(key, ENTRY_MODIFY, path)
-          else if (!exists && key.reportDeleteEvents) createEvent(key, ENTRY_DELETE, path)
-      })
-    }
-  }
-
-  private[this] val watcher: FileEventsApi = FileEventsApi.apply(onFileEvent, dropEvent)
-  override def close(): Unit = watcher.synchronized {
-    if (open.compareAndSet(true, false)) {
-      watcher.close()
-      executor.shutdownNow()
-      executor.awaitTermination(5, TimeUnit.SECONDS)
-      ()
-    } else {}
-  }
+  private val underlying = com.swoval.files.RegisterableWatchServices.get()
+  private val keys: mutable.Map[JPath, WatchKey] =
+    Collections.synchronizedMap(new ConcurrentHashMap[JPath, WatchKey]()).asScala
+  private val isClosed = new AtomicBoolean(false)
+  def isOpen: Boolean = !isClosed.get
 
   override def init(): Unit = {}
 
-  override def poll(timeout: Duration): WatchKey =
-    if (isOpen) {
-      readyKeys.poll(timeout.toNanos, TimeUnit.NANOSECONDS)
-    } else throw new ClosedWatchServiceException
-
   override def pollEvents(): Map[WatchKey, immutable.Seq[WatchEvent[JPath]]] =
-    registered
-      .synchronized(registered.flatMap {
-        case (_, (k, _)) =>
-          val events = k.pollEvents()
-          if (events.isEmpty) Nil
-          else Seq(k -> events.iterator.asScala.map(_.asInstanceOf[WatchEvent[JPath]]).toIndexedSeq)
-      })
-      .toMap[WatchKey, immutable.Seq[WatchEvent[JPath]]]
+    underlying.poll() match {
+      case null => Map.empty
+      case k =>
+        Map(k -> k.pollEvents().asScala.view.map(_.asInstanceOf[WatchEvent[JPath]]).toIndexedSeq)
+    }
+
+  override def poll(timeout: Duration): WatchKey =
+    underlying.poll(timeout.toNanos, TimeUnit.NANOSECONDS)
 
   override def register(path: JPath, events: WatchEvent.Kind[JPath]*): WatchKey = {
-    if (isOpen) {
-      registered.synchronized {
-        val realPath = path.toRealPath()
-        registered get realPath match {
-          case Some((k, _)) => k;
-          case _ =>
-            val key = new MacOSXWatchKey(realPath, queueSize, events: _*)
-            val flags = new Flags.Create().setNoDefer().setFileEvents().value
-            val id =
-              if (streams.exists(s => realPath.startsWith(s))) -1
-              else {
-                streams += realPath
-                watcher.createStream(realPath.toString, watchLatency.toMillis / 1000.0, flags)
-              }
-
-            registered += realPath -> (key -> id)
-            key
-        }
-      }
-    } else throw new ClosedWatchServiceException
+    val key = underlying.register(path.toRealPath(), events: _*)
+    keys.put(path, key)
+    key
   }
 
-  override def unregister(path: JPath): Unit =
-    if (isOpen) registered.synchronized {
-      registered.get(path) match {
-        case Some((k, i)) =>
-          if (i >= 0) watcher.stopStream(i)
-          k.cancel()
-          registered -= path
-        case None =>
-      }
-      ()
-    } else throw new ClosedWatchServiceException
-
-  private def createEvent(key: MacOSXWatchKey, kind: WatchEvent.Kind[JPath], file: JPath): Unit = {
-    val event = Event(kind, 1, file)
-    key.addEvent(event)
-    if (!readyKeys.contains(key)) {
-      readyKeys.offer(key)
-    }
-    ()
+  override def unregister(path: JPath): Unit = {
+    keys.remove(path) foreach (_.cancel())
   }
 
-  def isOpen: Boolean = open.get
-
-  private[this] val open = new AtomicBoolean(true)
-  private[this] val readyKeys = new LinkedBlockingQueue[MacOSXWatchKey]
-  private[this] val registered = mutable.Map.empty[JPath, (MacOSXWatchKey, Int)]
-}
-
-private case class Event[T](kind: WatchEvent.Kind[T], count: Int, context: T) extends WatchEvent[T]
-
-private class MacOSXWatchKey(val watchable: JPath, queueSize: Int, kinds: WatchEvent.Kind[JPath]*)
-    extends WatchKey {
-
-  override def cancel(): Unit = valid.set(false)
-
-  override def isValid: Boolean = valid.get
-
-  override def pollEvents(): JList[WatchEvent[_]] = this.synchronized {
-    val result = new mutable.ArrayBuffer[WatchEvent[_]](events.size).asJava
-    events.drainTo(result)
-    val overflowCount = overflow.getAndSet(0)
-    if (overflowCount != 0) {
-      result.add(Event(OVERFLOW, overflowCount, watchable))
-    }
-    Collections.unmodifiableList(result)
-  }
-
-  override def reset(): Boolean = true
-
-  override def toString = s"MacOSXWatchKey($watchable)"
-
-  lazy val reportCreateEvents: Boolean = kinds contains ENTRY_CREATE
-  lazy val reportModifyEvents: Boolean = kinds contains ENTRY_MODIFY
-  lazy val reportDeleteEvents: Boolean = kinds contains ENTRY_DELETE
-
-  private val events = new ArrayBlockingQueue[WatchEvent[_]](queueSize)
-  private val overflow = new AtomicInteger()
-  private val valid = new AtomicBoolean(true)
-
-  @inline def addEvent(event: Event[JPath]): Unit = this.synchronized {
-    if (!events.offer(event)) {
-      overflow.incrementAndGet()
-      ()
-    }
+  override def close(): Unit = if (isClosed.compareAndSet(false, true)) {
+    keys.values.foreach(_.cancel())
+    keys.clear()
+    underlying.close()
   }
 }

--- a/io/src/main/scala/sbt/io/Path.scala
+++ b/io/src/main/scala/sbt/io/Path.scala
@@ -377,7 +377,7 @@ sealed abstract class PathFinder {
    * Typical usage is <code>descendantsExcept("*.jar", ".svn")</code>
    */
   def descendantsExcept(include: FileFilter, intermediateExclude: FileFilter): PathFinder =
-    (this ** include) --- (this ** intermediateExclude ** include)
+    this ** (include -- intermediateExclude)
 
   /**
    * Evaluates this finder and converts the results to a `Seq` of distinct `File`s.

--- a/io/src/test/scala/sbt/internal/io/FileEventMonitorSpec.scala
+++ b/io/src/test/scala/sbt/internal/io/FileEventMonitorSpec.scala
@@ -1,0 +1,70 @@
+package sbt.internal.io
+
+import java.nio.file.{ Path, Paths }
+
+import org.scalatest.{ FlatSpec, Matchers }
+import sbt.io.{ FileEventMonitor, NullLogger, TypedPath }
+import sbt.io.FileEventMonitor.{ Creation, Deletion, Update }
+import sbt.io.FileTreeDataView.Entry
+
+import scala.concurrent.duration._
+
+class FileEventMonitorSpec extends FlatSpec with Matchers {
+  object TestEntry {
+    val EXISTS = 1
+    val DIRECTORY = 2
+    val FILE = 4
+    val LINK = 8
+    def apply(file: String, kind: Int): Entry[Path] = {
+      val path = Paths.get(file)
+      new Entry(new TestTypedPath(path, kind), Right(path))
+    }
+  }
+  import TestEntry._
+  class TestTypedPath(override val getPath: Path, kind: Int) extends TypedPath {
+    override def exists: Boolean = (kind & EXISTS) != 0
+    override def isDirectory: Boolean = (kind & DIRECTORY) != 0
+    override def isFile: Boolean = (kind & FILE) != 0
+    override def isSymbolicLink: Boolean = (kind & LINK) != 0
+  }
+  "anti-entropy" should "ignore redundant events" in {
+    val observers = new Observers[Path]
+    val antiEntropyPeriod = 20.millis
+    val monitor = FileEventMonitor.antiEntropy(observers, antiEntropyPeriod, NullLogger)
+    val entry = TestEntry("foo", FILE | EXISTS)
+    val start = Deadline.now
+    observers.onCreate(entry)
+    observers.onUpdate(entry, entry)
+    val unrelatedEntry = TestEntry("bar", FILE | EXISTS)
+    observers.onCreate(unrelatedEntry)
+    monitor.poll(antiEntropyPeriod).toSet shouldBe Set(Creation(entry), Creation(unrelatedEntry))
+    val wait = start + antiEntropyPeriod + 100.millis - Deadline.now
+    monitor.poll(wait) shouldBe Nil
+    observers.onUpdate(entry, entry)
+    monitor.poll(antiEntropyPeriod) shouldBe Seq(Update(entry, entry))
+  }
+  it should "quarantine deletions" in {
+    val observers = new Observers[Path]
+    val antiEntropyPeriod = 40.millis
+    val quarantinePeriod = antiEntropyPeriod / 2
+    val monitor =
+      FileEventMonitor.antiEntropy(observers, antiEntropyPeriod, NullLogger, quarantinePeriod)
+    val entry = TestEntry("foo", FILE)
+    observers.onDelete(entry)
+    monitor.poll(0.millis) shouldBe Nil
+    monitor.poll(quarantinePeriod * 2) shouldBe Seq(Deletion(entry))
+  }
+  it should "immediately trigger for creations" in {
+    val observers = new Observers[Path]
+    val antiEntropyPeriod = 40.millis
+    val quarantinePeriod = antiEntropyPeriod / 2
+    val monitor =
+      FileEventMonitor.antiEntropy(observers, antiEntropyPeriod, NullLogger, quarantinePeriod)
+    val deletedEntry = TestEntry("foo", FILE)
+    val newEntry = TestEntry("foo", FILE | EXISTS)
+    observers.onDelete(deletedEntry)
+    observers.onCreate(newEntry)
+
+    monitor.poll(0.millis) shouldBe Seq(Update(deletedEntry, newEntry))
+  }
+}

--- a/io/src/test/scala/sbt/internal/io/HybridEventMonitorSpec.scala
+++ b/io/src/test/scala/sbt/internal/io/HybridEventMonitorSpec.scala
@@ -1,0 +1,79 @@
+package sbt.internal.io
+
+import java.nio.file.{ Files, Path }
+
+import org.scalatest.{ FlatSpec, Matchers }
+import sbt.io._
+
+import scala.concurrent.duration._
+import HybridEventMonitorSpec._
+import sbt.io.FileTreeDataView.Observable
+
+class HybridEventMonitorSpec extends FlatSpec with Matchers {
+  it should "poll and monitor" in IO.withTemporaryDirectory { baseDir =>
+    val dir = baseDir.toPath.toRealPath()
+    val pollingDir = Files.createDirectory(dir.resolve("polling"))
+    val monitoredDir = Files.createDirectory(dir.resolve("monitored"))
+    val repo = FileRepository.hybrid((_: TypedPath).getPath, Source(pollingDir.toFile))
+    val sources = Seq(Source(pollingDir.toFile), Source(monitoredDir.toFile))
+    repo.register(pollingDir, Integer.MAX_VALUE)
+    repo.register(monitoredDir, Integer.MAX_VALUE)
+    val pollingFile = pollingDir.resolve("file")
+    val monitoredFile = monitoredDir.resolve("file")
+
+    try {
+      withMonitor(repo, sources) { monitor =>
+        Files.createFile(pollingFile)
+        assert(monitor.poll(5.seconds).nonEmpty)
+        repo.ls(pollingDir) shouldBe Seq(pollingFile)
+      }
+
+      withMonitor(repo, sources) { monitor =>
+        Files.createFile(monitoredFile)
+        assert(monitor.poll(5.seconds).nonEmpty)
+        repo.ls(monitoredDir) shouldBe Seq(monitoredFile)
+      }
+
+      val newPollingFile = pollingDir.resolve("new-file")
+      val newMonitoredFile = monitoredDir.resolve("new-file")
+      // This tests that monitoring still works when there is overlap of the registered files
+      repo.register(dir, Integer.MAX_VALUE)
+      withMonitor(repo, sources) { monitor =>
+        Files.createFile(newPollingFile)
+        assert(monitor.poll(5.seconds).nonEmpty)
+        repo.ls(pollingDir).toSet shouldBe Set(pollingFile, newPollingFile)
+      }
+      withMonitor(repo, sources) { monitor =>
+        Files.createFile(newMonitoredFile)
+        assert(monitor.poll(5.seconds).nonEmpty)
+        repo.ls(monitoredDir).toSet shouldBe Set(monitoredFile, newMonitoredFile)
+      }
+      val allPolling = Set(pollingDir, pollingFile, newPollingFile)
+      val allMonitored = Set(monitoredDir, monitoredFile, newMonitoredFile)
+      repo.ls(dir).toSet shouldBe (allPolling ++ allMonitored)
+    } finally {
+      repo.close()
+    }
+  }
+}
+
+object HybridEventMonitorSpec {
+  val antiEntropy: FiniteDuration = 0.seconds
+  val pollDelay: FiniteDuration = 100.millis
+  def withMonitor[T](observable: Observable[_], sources: Seq[Source])(
+      f: FileEventMonitor[_] => T): T = {
+    val monitor = observable match {
+      case r: HybridPollingFileRepository[_] =>
+        FileEventMonitor(r.toPollingObservable(pollDelay, sources, NullLogger))
+    }
+    try {
+      f(monitor)
+    } finally {
+      monitor.close()
+    }
+  }
+  implicit class FileRepositoryOps[+T](val fileRepository: FileRepository[T]) {
+    def ls(path: Path): Seq[Path] =
+      fileRepository.list(path, Integer.MAX_VALUE, (_: TypedPath) => true).map(_.getPath)
+  }
+}

--- a/io/src/test/scala/sbt/internal/io/HybridPollingFileRepositorySpec.scala
+++ b/io/src/test/scala/sbt/internal/io/HybridPollingFileRepositorySpec.scala
@@ -1,0 +1,64 @@
+package sbt.internal.io
+
+import java.nio.file.{ Files, Path }
+import java.util.concurrent.{ CountDownLatch, TimeUnit }
+
+import org.scalatest.{ FlatSpec, Matchers }
+import sbt.io.FileRepositorySpec.FileRepositoryOps
+import sbt.io.FileTreeDataView.Observer
+import sbt.io._
+
+class HybridPollingFileRepositorySpec extends FlatSpec with Matchers {
+  val allPass: TypedPath => Boolean = (_: TypedPath) => true
+  it should "poll specified directories " in IO.withTemporaryDirectory { baseDir =>
+    val dir = Files.createDirectory(baseDir.toPath.resolve("regular")).toRealPath()
+    val pollingDir = Files.createDirectory(baseDir.toPath.resolve("polling")).toRealPath()
+    val latch = new CountDownLatch(1)
+    val repo =
+      FileRepository.hybrid((_: TypedPath).getPath, Source(pollingDir.toFile))
+    try {
+      repo.register(dir, maxDepth = Integer.MAX_VALUE)
+      repo.register(pollingDir, maxDepth = Integer.MAX_VALUE)
+      val regularFile = dir.resolve("regular-file")
+      repo.addObserver(new Observer[Path] {
+        override def onCreate(newEntry: FileTreeDataView.Entry[Path]): Unit = {
+          if (newEntry.typedPath.getPath == regularFile) {
+            latch.countDown()
+          }
+        }
+        override def onDelete(oldEntry: FileTreeDataView.Entry[Path]): Unit = {}
+
+        override def onUpdate(oldEntry: FileTreeDataView.Entry[Path],
+                              newEntry: FileTreeDataView.Entry[Path]): Unit = {}
+      })
+
+      def listBoth: Seq[Path] = repo.ls(dir) ++ repo.ls(pollingDir)
+      listBoth shouldBe 'empty
+      val pollingFile = Files.createFile(pollingDir.resolve("polling-file"))
+      // If we weren't polling then it would not be guaranteed that the polling file would be
+      // visible yet.
+      listBoth shouldBe Seq(pollingFile)
+      Files.createFile(regularFile)
+      // Here we need to wait for the latch to ensure that the regular file is visible to the cache.
+      assert(latch.await(1, TimeUnit.SECONDS))
+      listBoth.toSet shouldBe Set(pollingFile, regularFile)
+    } finally {
+      repo.close()
+    }
+  }
+  it should "not return duplicates" in IO.withTemporaryDirectory { baseDir =>
+    val dir = baseDir.toPath
+    val subdir = Files.createDirectory(dir.resolve("subdir"))
+    val nested = Files.createDirectory(subdir.resolve("nested"))
+    val file = Files.createFile(nested.resolve("file"))
+    val filter: FileFilter = new SimpleFileFilter(_.getName != subdir.toFile.getName)
+    val repo =
+      FileRepository.hybrid((_: TypedPath).getPath, Source(subdir.toFile, filter, NothingFilter))
+    try {
+      repo.register(dir, Integer.MAX_VALUE)
+      repo.ls(dir).sorted shouldBe Seq(subdir, nested, file)
+    } finally {
+      repo.close()
+    }
+  }
+}

--- a/io/src/test/scala/sbt/internal/io/SourceModificationWatchSpec.scala
+++ b/io/src/test/scala/sbt/internal/io/SourceModificationWatchSpec.scala
@@ -412,7 +412,7 @@ private[sbt] trait EventMonitorSpec { self: FlatSpec with Matchers =>
 
   def watchTest(monitor: FileEventMonitor[_])(modifier: => Unit): Boolean = {
     modifier
-    monitor.poll(maxWait).nonEmpty
+    monitor.poll(maxWait * 2).nonEmpty
   }
 
   def watchTest(base: File, expectedTrigger: Boolean = true)(modifier: => Unit): Assertion = {

--- a/io/src/test/scala/sbt/internal/io/SourceModificationWatchSpec.scala
+++ b/io/src/test/scala/sbt/internal/io/SourceModificationWatchSpec.scala
@@ -1,23 +1,24 @@
 package sbt.internal.io
 
 import java.io.IOException
-import java.nio.file.{ ClosedWatchServiceException, Files, Paths }
+import java.nio.file.{ ClosedWatchServiceException, Files, Path, Paths }
 
 import org.scalatest.{ Assertion, FlatSpec, Matchers }
-import sbt.internal.io.EventMonitor.{ Logger, NullLogger }
+import sbt.internal.io.EventMonitorSpec._
+import sbt.io.FileEventMonitor.Event
+import sbt.io.FileTreeDataView.{ Entry, Observable, Observer }
 import sbt.io.syntax._
-import sbt.io.{ IO, SimpleFilter, WatchService }
+import sbt.io.{ FileTreeDataView, NullLogger, TypedPath, WatchService, _ }
 
 import scala.annotation.tailrec
 import scala.concurrent.duration._
 
 private[sbt] trait EventMonitorSpec { self: FlatSpec with Matchers =>
   def pollDelay: FiniteDuration
-  def newEventMonitor(sources: Seq[Source],
-                      antiEntropy: FiniteDuration = 0.milliseconds,
-                      tc: () => Boolean = defaultTerminationCondition,
-                      logger: Logger = NullLogger): EventMonitor
-  val maxWait = 2 * pollDelay
+  def newObservable(source: Seq[Source]): Observable[_]
+  def newObservable(file: File): Observable[_] =
+    newObservable(Seq(Source(file.toPath.toRealPath().toFile)))
+  private val maxWait = 2 * pollDelay
 
   it should "detect modified files" in IO.withTemporaryDirectory { dir =>
     val parentDir = dir / "src" / "watchme"
@@ -232,32 +233,22 @@ private[sbt] trait EventMonitorSpec { self: FlatSpec with Matchers =>
       val parentDir = dir / "src" / "watchme"
       val subDir = parentDir / "subdir"
       IO.createDirectory(parentDir)
-      val firstDeadline = maxWait.fromNow
-      val secondDeadline = (2 * maxWait).fromNow
-      var firstDeadlinePassed = false
 
-      val tc = () => {
-        if (!firstDeadlinePassed) {
-          firstDeadlinePassed = firstDeadline.isOverdue()
-          firstDeadlinePassed
-        } else {
-          secondDeadline.isOverdue()
-        }
-      }
-      val monitor = defaultMonitor(parentDir, tc = tc)
+      val observable = newObservable(parentDir.scalaSource)
+      val monitor = FileEventMonitor(observable)
       try {
         val triggered0 = watchTest(monitor) {
           IO.createDirectory(subDir)
         }
         triggered0 shouldBe false
-        monitor.state().count shouldBe 1
 
         val triggered1 = watchTest(monitor) {
           IO.delete(subDir)
         }
         triggered1 shouldBe false
-        monitor.state().count shouldBe 1
-      } finally monitor.close()
+      } finally {
+        monitor.close()
+      }
   }
 
   it should "detect deletion of a directory containing watched files" in IO.withTemporaryDirectory {
@@ -267,21 +258,19 @@ private[sbt] trait EventMonitorSpec { self: FlatSpec with Matchers =>
       val src = subDir / "src.scala"
 
       IO.createDirectory(parentDir)
-
-      val monitor = defaultMonitor(parentDir)
+      val observable = newObservable(parentDir.scalaSource)
+      val monitor = FileEventMonitor(observable)
       try {
         val triggered0 = watchTest(monitor) {
           IO.createDirectory(subDir)
           IO.touch(src)
         }
         triggered0 shouldBe true
-        monitor.state().count shouldBe 2
 
         val triggered1 = watchTest(monitor) {
           IO.delete(subDir)
         }
         triggered1 shouldBe true
-        monitor.state().count shouldBe 3
       } finally monitor.close()
   }
 
@@ -291,7 +280,9 @@ private[sbt] trait EventMonitorSpec { self: FlatSpec with Matchers =>
       val file = parentDir / "Foo.scala"
 
       writeNewFile(file, "foo")
-      val monitor = defaultMonitor(parentDir, antiEntropy = maxWait * 2)
+      val observable = newObservable(parentDir)
+      // Choose a very long anti-entropy period to ensure that the second trigger doesn't happen
+      val monitor = FileEventMonitor.antiEntropy(observable, 10.seconds, NullLogger)
       try {
         val triggered0 = watchTest(monitor) {
           IO.write(file, "bar")
@@ -299,12 +290,24 @@ private[sbt] trait EventMonitorSpec { self: FlatSpec with Matchers =>
         assert(triggered0)
         assert(IO.read(file) == "bar")
 
-        val triggered1 = watchTest(monitor) {
-          IO.write(file, "baz")
+        val deadline = maxWait.fromNow
+        @tailrec
+        def poll(): Boolean = {
+          val wait = deadline - Deadline.now
+          monitor.poll(wait) match {
+            case sources if sources.map(_.entry.typedPath.getPath).contains(file.toPath) => true
+            case _ if Deadline.now < deadline                                            => poll()
+            case _                                                                       => false
+          }
         }
+        monitor.drain(maxWait)
+        IO.write(file, "baz")
+        val triggered1 = poll()
         assert(!triggered1)
         assert(IO.read(file) == "baz")
-      } finally monitor.close()
+      } finally {
+        monitor.close()
+      }
     }
 
   it should "ignore valid files in non-recursive subdirectories" in IO.withTemporaryDirectory {
@@ -313,15 +316,17 @@ private[sbt] trait EventMonitorSpec { self: FlatSpec with Matchers =>
       val source =
         Source(dir.toPath.toRealPath().toFile, "*.scala", new SimpleFilter(_.startsWith(".")))
           .withRecursive(false)
-      val tc = defaultTerminationCondition
-      val monitor: EventMonitor = newEventMonitor(Seq(source), 0.millis, tc)
+      val observable = newObservable(Seq(source))
+      val monitor = FileEventMonitor(observable)
       try {
         val triggered = watchTest(monitor) {
           IO.write(file, "foo")
         }
         assert(!triggered)
         assert(IO.read(file) == "foo")
-      } finally monitor.close()
+      } finally {
+        monitor.close()
+      }
   }
 
   it should "log triggered files" in IO.withTemporaryDirectory { dir =>
@@ -333,94 +338,95 @@ private[sbt] trait EventMonitorSpec { self: FlatSpec with Matchers =>
     val sources = Seq(
       Source(parentDir.toPath.toRealPath().toFile, "*.scala", new SimpleFilter(_.startsWith("."))))
     var lines: Seq[String] = Nil
-    val logger = new EventMonitor.Logger {
+    val logger = new Logger {
       override def debug(msg: => Any): Unit = lines.synchronized {
         lines :+= msg.toString
       }
     }
-    val tc = defaultTerminationCondition
-    val monitor = newEventMonitor(sources, 0.seconds, tc, logger)
+    val observable = newObservable(sources)
+    val monitor = FileEventMonitor(observable, logger)
     try {
       val triggered = watchTest(monitor) {
         IO.write(file, "bar")
       }
       assert(triggered)
-      assert(monitor.state().count == 2)
-      assert(lines.exists(_.startsWith("Triggered")))
-    } finally monitor.close()
+      assert(lines.exists(_.startsWith("Received")))
+    } finally {
+      monitor.close()
+    }
   }
 
   it should "handle rapid creation of many subdirectories and files" in IO.withTemporaryDirectory {
     dir =>
       val parentDir = dir / "src" / "watchme"
       Files.createDirectories(parentDir.toPath)
-      val subdirCount = 2000
+      val realParent = parentDir.toPath.toRealPath()
+      val subdirCount = 200
       val subdirFileCount = 4
-      var files = Seq.empty[File]
 
       // Longer timeout because there are many file system operations. This can be very expensive
-      // especially in the PollingWatchSpec since both the PollingWatchService and the EventMonitor
-      // overflow handler are hammering the file system. To minimize the conflicts, we set a long
-      // interval between polls in the PollingWatchService using getServiceWithPollDelay. The
-      // timeout was increased from 20.seconds to 40.seconds to address transient failures of
-      // this test on Appveyor windows builds.
-      val deadline = 40.seconds.fromNow
-      val monitor = defaultMonitor(parentDir, tc = () => deadline.isOverdue)
+      // especially in the PollingWatchSpec since both the PollingWatchService and the
+      // WatchServiceBackedObserable overflow handler are hammering the file system. To minimize the
+      // conflicts, we set a long interval between polls in the PollingWatchService using
+      // getServiceWithPollDelay. The timeout was increased from 20.seconds to 40.seconds to address
+      // transient failures of this test on Appveyor windows builds.
+      val observable = newObservable(realParent.toFile)
+      val monitor = FileEventMonitor(observable)
       try {
-        val triggered0 = watchTest(monitor) {
-          val subdirs =
-            (1 to subdirCount).map(i =>
-              Files.createDirectories(parentDir.toPath.resolve(s"subdir-$i")))
-          files = subdirs.flatMap { subdir =>
-            subdir.toFile +: (1 to subdirFileCount).map { j =>
-              Files.write(subdir.resolve(s"file-$j.scala"), s"foo".getBytes).toFile
-            }
+        val subdirs =
+          (1 to subdirCount).map(i => Files.createDirectories(realParent.resolve(s"subdir-$i")))
+        val files = subdirs.flatMap { subdir =>
+          subdir +: (1 to subdirFileCount).map { j =>
+            Files.write(subdir.resolve(s"file-$j.scala"), s"foo".getBytes)
           }
         }
+        val allPaths = files.toSet
         val lastFile = files.last
-        assert(triggered0)
-        assert(IO.read(lastFile) == s"foo")
 
-        val triggered1 = watchTest(monitor) {
-          IO.write(lastFile, "baz")
+        // There is a bug in older java versions where sometimes the watch context can be incorrect
+        // when we are simultaneously watching and registering new paths. It is fixed in the latest
+        // openjdk 8 and openjdk and oracle >= 9, but in CI we may expect th
+        // DefaultWatchServiceSpec to occasionally fail.
+        // http://blog.omega-prime.co.uk/2015/11/14/beware-java-nio-file-watchservice-is-subtly-broken-on-linux/
+        val triggeredPaths =
+          monitor.drain(maxWait * 4).map(_.entry.typedPath.getPath).toSet.intersect(allPaths)
+        if (triggeredPaths != allPaths) {
+          val diff = allPaths diff triggeredPaths
+          if (diff.size > 5)
+            println(diff.take(5).mkString("", "\n", s"\n and ${diff.size - 5} more ..."))
+          else println(diff mkString "\n")
+          // tolerate the failures on linux until we upgrade travis to java 9 or greater
+          assert(System.getProperty("os.name", "").startsWith("Linux"))
         }
-        assert(triggered1)
-        assert(IO.read(lastFile) == "baz")
-      } finally monitor.close()
+
+        assert(IO.read(lastFile.toFile) == s"foo")
+        IO.write(lastFile.toFile, "baz")
+        val updates = monitor.drain(maxWait * 4)
+        val result = updates.exists(_.entry.typedPath.getPath == lastFile)
+        assert(result)
+        assert(IO.read(lastFile.toFile) == "baz")
+      } finally {
+        monitor.close()
+      }
   }
-  def watchTest(eventMonitor: EventMonitor)(modifier: => Unit): Boolean = {
+
+  def watchTest(monitor: FileEventMonitor[_])(modifier: => Unit): Boolean = {
     modifier
-    eventMonitor.awaitEvent()
+    monitor.poll(maxWait).nonEmpty
   }
 
   def watchTest(base: File, expectedTrigger: Boolean = true)(modifier: => Unit): Assertion = {
     val sources = Seq(
       Source(base.toPath.toRealPath().toFile, "*.scala", new SimpleFilter(_.startsWith("."))))
-    val monitor = newEventMonitor(sources)
+    val observable = newObservable(sources)
     try {
-      val triggered = watchTest(monitor)(modifier)
+      val triggered = watchTest(FileEventMonitor(observable))(modifier)
       triggered shouldBe expectedTrigger
-    } finally monitor.close()
+    } finally {
+      observable.close()
+    }
   }
 
-  def defaultTerminationCondition: () => Boolean = {
-    lazy val deadline = maxWait.fromNow
-    () =>
-      {
-        val res = deadline.isOverdue()
-        if (!res) Thread.sleep(5)
-        res
-      }
-  }
-
-  private def defaultMonitor(base: File,
-                             antiEntropy: FiniteDuration = 0.milliseconds,
-                             tc: () => Boolean = defaultTerminationCondition,
-                             logger: Logger = NullLogger): EventMonitor = {
-    val sources = Seq(
-      Source(base.toPath.toRealPath().toFile, "*.scala", new SimpleFilter(_.startsWith("."))))
-    newEventMonitor(sources, antiEntropy, tc, logger)
-  }
   @tailrec
   final def writeNewFile(file: File, content: String, attempt: Int = 0): Unit = {
     if (attempt == 0) IO.write(file, content)
@@ -431,6 +437,54 @@ private[sbt] trait EventMonitorSpec { self: FlatSpec with Matchers =>
     if (!res) writeNewFile(file, content, attempt + 1)
   }
 
+}
+
+object EventMonitorSpec {
+  // This can't be defined in MonitorOps because of a bug in the scala 2.10 compiler
+  @tailrec
+  private def drain(monitor: FileEventMonitor[_],
+                    duration: FiniteDuration,
+                    events: Seq[Event[_]]): Seq[Event[_]] = {
+    val newEvents = monitor.poll(duration)
+    if (newEvents.isEmpty) events else drain(monitor, duration, events ++ newEvents)
+  }
+  implicit class MonitorOps(val monitor: FileEventMonitor[_]) extends AnyVal {
+    def drain(duration: FiniteDuration, events: Seq[Event[_]] = Nil): Seq[Event[_]] =
+      EventMonitorSpec.drain(monitor, duration, events)
+  }
+  implicit class FileOps(val file: File) extends AnyVal {
+    def scalaSource: Seq[Source] =
+      Seq(Source(file.toPath.toRealPath().toFile, "*.scala", HiddenFileFilter))
+  }
+  private class FilteredObservable[T](observable: Observable[T], filter: Entry[T] => Boolean)
+      extends Observable[T] {
+    override def addObserver(observer: FileTreeDataView.Observer[T]): Int =
+      observable.addObserver(new Observer[T] {
+        override def onCreate(newEntry: Entry[T]): Unit =
+          if (filter(newEntry)) observer.onCreate(newEntry)
+        override def onDelete(oldEntry: Entry[T]): Unit =
+          if (filter(oldEntry)) observer.onDelete(oldEntry)
+        override def onUpdate(oldEntry: Entry[T], newEntry: Entry[T]): Unit = {
+          if (filter(newEntry)) observer.onUpdate(oldEntry, newEntry)
+        }
+      })
+    override def removeObserver(handle: Int): Unit = observable.removeObserver(handle)
+    override def close(): Unit = observable.close()
+  }
+  implicit class ObservableOps[T](val observable: Observable[T]) extends AnyVal {
+    def filter(f: Entry[T] => Boolean): Observable[T] = new FilteredObservable[T](observable, f)
+  }
+}
+
+class FileRepositoryEventMonitorSpec extends FlatSpec with Matchers with EventMonitorSpec {
+  override def pollDelay: FiniteDuration = 100.millis
+
+  override def newObservable(sources: Seq[Source]): Observable[_] = {
+    val repository = FileRepository.default((_: TypedPath).getPath)
+    sources foreach (s =>
+      repository.register(s.base.toPath, if (s.recursive) Integer.MAX_VALUE else 0))
+    repository.filter(e => sources.exists(s => s.accept(e.typedPath.getPath)))
+  }
 }
 abstract class SourceModificationWatchSpec(
     getServiceWithPollDelay: FiniteDuration => WatchService,
@@ -458,10 +512,16 @@ abstract class SourceModificationWatchSpec(
     service.close()
   }
 
-  override def newEventMonitor(sources: Seq[Source],
-                               antiEntropy: FiniteDuration,
-                               tc: () => Boolean,
-                               logger: Logger): EventMonitor = {
-    EventMonitor(WatchState.empty(getService, sources), pollDelay, antiEntropy, tc(), logger)
+  override def newObservable(sources: Seq[Source]): FileTreeDataView.Observable[_] = {
+    val watchState = WatchState.empty(getService, sources)
+    val observable = new WatchServiceBackedObservable[Path](watchState,
+                                                            5.millis,
+                                                            (_: TypedPath).getPath,
+                                                            closeService = true,
+                                                            NullLogger)
+    observable.filter((entry: Entry[Path]) => {
+      val path = entry.typedPath.getPath
+      sources.exists(_.accept(path))
+    })
   }
 }

--- a/io/src/test/scala/sbt/io/FileRepositorySpec.scala
+++ b/io/src/test/scala/sbt/io/FileRepositorySpec.scala
@@ -1,0 +1,228 @@
+package sbt.io
+
+import java.nio.file.attribute.FileTime
+import java.nio.file.{ Files, Path => JPath, Paths => JPaths }
+import java.util.concurrent.{ CountDownLatch, TimeUnit }
+
+import org.scalatest.{ FlatSpec, Matchers }
+import sbt.io.FileTreeDataView.Entry
+import sbt.io.FileRepositorySpec._
+
+import scala.concurrent.duration._
+import sbt.io.FileTreeView.AllPass
+
+private[io] trait RepositoryFactory {
+  def newRepository[T](converter: TypedPath => T): FileRepository[T]
+}
+object FileRepositorySpec {
+  implicit class FileRepositoryOps[T](val fileCache: FileRepository[T]) extends AnyVal {
+    def ls(path: JPath,
+           maxDepth: Int = Integer.MAX_VALUE,
+           filter: TypedPath => Boolean = AllPass): Seq[JPath] =
+      fileCache.list(path, maxDepth, filter).map(_.getPath)
+  }
+  implicit class CountdownLatchOps(val latch: CountDownLatch) extends AnyVal {
+    def await(duration: Duration): Boolean = latch.await(duration.toNanos, TimeUnit.NANOSECONDS)
+  }
+  def asPath(typedPath: TypedPath): JPath = typedPath.getPath
+  private val DEFAULT_TIMEOUT = 1.second
+  def using[T, R](fileCache: => FileRepository[T])(f: FileRepository[T] => R): R = {
+    val cache = fileCache
+    try f(cache)
+    finally cache.close()
+  }
+  def withTempDir[R](f: JPath => R): R =
+    IO.withTemporaryDirectory(dir => f(dir.toPath.toRealPath()))
+  def withTempDir[R](dir: JPath)(f: JPath => R): R = {
+    val subdir = Files.createTempDirectory(dir, "tmp")
+    try f(subdir)
+    finally IO.delete(subdir.toFile)
+  }
+  def withTempFile[R](dir: JPath)(f: JPath => R): R = {
+    val file = Files.createTempFile(dir, "", "").toRealPath()
+    try {
+      f(file)
+    } finally {
+      Files.deleteIfExists(file)
+      ()
+    }
+  }
+  def withTempFile[R](f: JPath => R): R = withTempDir(withTempFile(_)(f))
+  def simpleCache(f: Entry[JPath] => Unit = _ => {})(
+      implicit factory: RepositoryFactory): FileRepository[JPath] = {
+    val res = factory.newRepository(asPath)
+    res.addObserver(f)
+    res
+  }
+  def simpleCache(observer: FileTreeDataView.Observer[JPath])(
+      implicit factory: RepositoryFactory): FileRepository[JPath] = {
+    val res = factory.newRepository(asPath)
+    res.addObserver(observer)
+    res
+  }
+  case class LastModified(at: Long)
+}
+class FileRepositorySpec(implicit factory: RepositoryFactory) extends FlatSpec with Matchers {
+  "register" should "see existing files" in withTempFile { file =>
+    using(simpleCache()) { c =>
+      c.register(file.getParent, Integer.MAX_VALUE)
+      c.list(file.getParent, Integer.MAX_VALUE, AllPass).map(_.getPath) shouldBe Seq(file)
+    }
+  }
+  it should "detect new files" in withTempDir { dir =>
+    val latch = new CountDownLatch(1)
+    using(simpleCache((e: Entry[JPath]) => latch.countDown())) { c =>
+      c.register(dir, Integer.MAX_VALUE)
+      withTempFile(dir) { f =>
+        assert(latch.await(DEFAULT_TIMEOUT))
+        c.ls(dir, Integer.MAX_VALUE, AllPass) shouldBe Seq(f)
+      }
+    }
+  }
+  it should "detect new subdirectories" in withTempDir { dir =>
+    val latch = new CountDownLatch(1)
+    using(simpleCache((_: Entry[JPath]) => latch.countDown())) { c =>
+      c.register(dir, Integer.MAX_VALUE)
+      withTempDir(dir) { subdir =>
+        assert(latch.await(DEFAULT_TIMEOUT))
+        c.ls(dir, Integer.MAX_VALUE, AllPass) shouldBe Seq(subdir)
+      }
+    }
+  }
+  it should "detect move events" in withTempDir { dir =>
+    val latch = new CountDownLatch(2)
+    val initial = Files.createTempFile(dir, "move", "")
+    val moved = JPaths.get(s"${initial.toString}.moved")
+    val onChange = (_: Entry[JPath]) => latch.countDown()
+    val onUpdate = (_: Entry[JPath], _: Entry[JPath]) => {}
+    using(simpleCache(FileTreeDataView.Observer[JPath](onChange, onChange, onUpdate))) { c =>
+      c.register(dir, maxDepth = 0)
+      c.ls(dir, maxDepth = 0) === Seq(initial)
+      Files.move(initial, moved)
+      assert(latch.await(DEFAULT_TIMEOUT))
+      c.ls(dir, maxDepth = 0) === Seq(moved)
+    }
+  }
+  it should "ignore children of subdirectories when recursive flag is false" in withTempDir { dir =>
+    withTempDir(dir) { subdir =>
+      val fileLatch = new CountDownLatch(1)
+      val subdirLatch = new CountDownLatch(1)
+      using(simpleCache((e: Entry[JPath]) => {
+        val path = e.typedPath.getPath
+        if (path.startsWith(subdir) && path != subdir) fileLatch.countDown()
+        else if (path == subdir && Files.getLastModifiedTime(path).toMillis == 2000)
+          subdirLatch.countDown()
+      })) { c =>
+        c.register(dir, maxDepth = 0)
+        withTempFile(subdir) { f =>
+          assert(Files.exists(f))
+          assert(fileLatch.getCount == 1) // The child creation should not have triggered a callback
+          Files.setLastModifiedTime(subdir, FileTime.fromMillis(2000))
+          assert(subdirLatch.await(DEFAULT_TIMEOUT))
+          c.ls(dir) === Seq(subdir)
+        }
+      }
+    }
+  }
+  it should "add recursive flag when previously set to false" in withTempDir { dir =>
+    withTempDir(dir) { subdir =>
+      withTempFile(subdir) { f =>
+        using(simpleCache()) { c =>
+          c.register(dir, maxDepth = 0)
+          c.ls(dir).toSet shouldBe Set(subdir)
+          c.register(dir, Integer.MAX_VALUE)
+          c.ls(dir).toSet shouldBe Set(subdir, f)
+        }
+      }
+    }
+  }
+  it should "not remove recursive flag when already set" in withTempDir { dir =>
+    withTempDir(dir) { subdir =>
+      withTempFile(subdir) { f =>
+        using(simpleCache()) { c =>
+          c.register(dir, maxDepth = Integer.MAX_VALUE)
+          c.ls(dir).toSet shouldBe Set(subdir, f)
+          c.register(dir, maxDepth = 0)
+          c.ls(dir).toSet shouldBe Set(subdir, f)
+        }
+      }
+    }
+  }
+
+  it should "detect many creations and deletions" in withTempDir { dir =>
+    val filesToAdd = 1000
+    var files = Set.empty[JPath]
+    val creationLatch = new CountDownLatch(filesToAdd * 2)
+    val deletionLatch = new CountDownLatch(filesToAdd * 2)
+    val observer = FileTreeDataView.Observer[JPath](onCreate = _ => creationLatch.countDown(),
+                                                    onDelete = _ => deletionLatch.countDown(),
+                                                    onUpdate = (_, _) => {})
+    using(simpleCache(observer)) { c =>
+      c.register(dir, maxDepth = Integer.MAX_VALUE)
+
+      withThread("file-creation-thread") {
+        files = (0 until filesToAdd).flatMap { i =>
+          val subdir = Files.createTempDirectory(dir, s"subdir-$i-")
+          val file = Files.createTempFile(subdir, s"file-$i-", "")
+          Seq(subdir, file)
+        }.toSet
+      } {
+        assert(creationLatch.await(DEFAULT_TIMEOUT * 10))
+        c.ls(dir).toSet shouldBe files
+      }
+
+      withThread("file-deletion-thread") {
+        files.foreach(p => if (Files.isDirectory(p)) IO.delete(p.toFile))
+      } {
+        assert(deletionLatch.await(DEFAULT_TIMEOUT * 10))
+        c.ls(dir) shouldBe 'empty
+      }
+    }
+  }
+
+  "updates" should "be detected" in withTempFile { file =>
+    val latch = new CountDownLatch(1)
+    using(FileRepository.default[LastModified]((p: TypedPath) =>
+      LastModified(Files.getLastModifiedTime(p.getPath).toMillis))) { c =>
+      c.addObserver(
+        FileTreeDataView.Observer[LastModified](
+          (_: Entry[LastModified]) => {},
+          (_: Entry[LastModified]) => {},
+          (oldEntry: Entry[LastModified], newEntry: Entry[LastModified]) =>
+            if (oldEntry != newEntry) latch.countDown()
+        )
+      )
+      c.register(file.getParent, maxDepth = Integer.MAX_VALUE)
+      val Seq(fileEntry) = c.listEntries(file.getParent, maxDepth = Integer.MAX_VALUE, AllPass)
+      val lastModified = fileEntry.value
+      lastModified.right.map((_: LastModified).at) shouldBe Right(
+        Files.getLastModifiedTime(file).toMillis)
+      val updatedLastModified = 2000L
+      Files.setLastModifiedTime(file, FileTime.fromMillis(updatedLastModified))
+      assert(latch.await(DEFAULT_TIMEOUT))
+      val Seq(newFileEntry) = c.listEntries(file.getParent, maxDepth = Integer.MAX_VALUE, AllPass)
+      newFileEntry.value.right.map(_.at) shouldBe Right(updatedLastModified)
+    }
+  }
+
+  private def withThread[R](name: String)(body: => Unit)(f: => R): Unit = {
+    val thread = new Thread(s"FileRepositorySpec-$name") {
+      override def run(): Unit = body
+      setDaemon(true)
+      start()
+    }
+    try {
+      f
+      ()
+    } finally {
+      thread.interrupt()
+      thread.join(5000L)
+    }
+  }
+
+}
+class DefaultFileRepositorySpec
+    extends FileRepositorySpec()(new RepositoryFactory {
+      override def newRepository[T](converter: TypedPath => T): FileRepository[T] =
+        FileRepository.default(converter)
+    })

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,5 +18,5 @@ object Dependencies {
   }
   val jna = "net.java.dev.jna" % "jna" % "4.5.0"
   val jnaPlatform = "net.java.dev.jna" % "jna-platform" % "4.5.0"
-  val appleFileEvents = "com.swoval" % "apple-file-events" % "1.3.2"
+  val swovalFiles = "com.swoval" % "file-tree-views" % "2.0.0"
 }


### PR DESCRIPTION
This is a large pull request that is the culmination of a number of month's work trying to improve the overall io and watch performance of sbt. For the most part, I've broken the commits up so that each one more or less stands on its own. I am doing it as one large pull request just because the overhead of making 20 partially dependent commits feels to high.

This commit uses apis that I developed in the swoval file-tree-views library that improve the performance of traversing the file system tree and also provide a dynamically updating in-memory cache of the file system.

As I describe in the file-tree-views readme, it is surprisingly expensive to descend the file system tree because all of the built in jvm apis require a stat of each file to determine if its a directory or a regular file. In the swoval library, I provide jni native libraries that take advantage of extra information in the system call for listing directories to traverse the tree without stat-ing any of the files. This can reduce the run time of traversal of a directory by 3-5x. It was straightforward to update the PathFinder implementations to use the swoval implementations. Because there is some risk that there is a bad bug in the library, I still allow users to fallback to the built-in java implementations via a system property (I have never seen any unexpected behavior, but I can't rule it out in every environment).

Secondly, I add support to cache a portion of the file system. The motivation is so that we can reduce the latency between the beginning of the compile task to when we actually start compilation. Zinc needs to compare file hashes so right now, sbt has to list all the files and compute the hash. The hash is fast, but the entire process is highly io bound. I seem to get roughly 10K iops on my mac with an ssd so it is perhaps unsurprising that before starting compilation I see sbt doing about 700ms of io before compilation starts in a project with 5000 files. By instead using an in-memory cache of the file system that precomputes the hashes, I've seen that 700ms drop drop to about 100-150. As a bonus, since we are already monitoring the file system to maintain the cache, we can re-use the cache in continuous builds by adding a listener to the cache's observable.

Finally, I make some improvements to the watch api for sbt. I refactor the EventMonitor so that it returns more information to sbt. I use this to make continuous builds testable by allowing the user to provide arbitrary termination conditions which do not depend on reading from System.in. In addition, I am able to implement automatic project reloading when the meta build files change. This is a feature that mill advertises as an improvement over sbt: http://www.lihaoyi.com/post/MillBetterScalaBuilds.html.

I have worked as hard as I could to try and preserve all existing behavior for users. In a number of places, I provide multiple implementations that are user configurable via a system property or sbt setting. In an ideal world, the majority of sbt users notice nothing after the change except that sbt feels snappier than before.

There also was an issue that watching a nested symlinked directory did not work on osx. This was because osx file watchers are all recursive, so I'd added logic to the swoval file events api that pruned any watches for any watches of a descendant of a watched directory. When there are no symlinks, this works great and lowers the resource cost of the watch, but in the presence of a symlinked directory descendant, we'd lose the updates. I fixed this upstream in swoval and I even enhanced it so that updates of symlinked files are detected by the watch service. This enhancement is only available using the swoval file repository and will not be available using the WatchServiceBackedObservable implementation of the FileEventMonitor.