### PR TITLE
Fix IO.relativize

### DIFF
--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -18,7 +18,7 @@ import java.io.{
 import java.io.{ ObjectInputStream, ObjectStreamClass, FileNotFoundException }
 import java.net.{ URI, URISyntaxException, URL }
 import java.nio.charset.Charset
-import java.nio.file.FileSystems
+import java.nio.file.{ FileSystems, Path => NioPath }
 import java.nio.file.attribute.PosixFilePermissions
 import java.util.Properties
 import java.util.jar.{ Attributes, JarEntry, JarOutputStream, Manifest }
@@ -608,9 +608,23 @@ object IO {
    * If `file` or `base` are not absolute, they are first resolved against the current working directory.
    */
   def relativize(base: File, file: File): Option[String] = {
-    val basePath = (if (base.isAbsolute) base else base.getCanonicalFile).toPath
-    val filePath = (if (file.isAbsolute) file else file.getCanonicalFile).toPath
-    if ((filePath startsWith basePath) || (filePath.normalize() startsWith basePath.normalize())) {
+    // "On UNIX systems, a pathname is absolute if its prefix is "/"."
+    // https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#isAbsolute
+    // "This typically involves removing redundant names such as "." and ".." from the pathname, resolving symbolic links (on UNIX platforms)"
+    // https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#getCanonicalPath()
+    // We do not want to use getCanonicalPath because if we resolve the symbolic link, that could change
+    // the outcome of copyDirectory's target structure.
+    // Path#normailize is able to expand ".." without expanding the symlink.
+    // https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#normalize()
+    // "Returns a path that is this path with redundant name elements eliminated."
+    def toAbsolutePath(x: File): NioPath = {
+      val p = x.toPath
+      if (!p.isAbsolute) p.toAbsolutePath
+      else p
+    }
+    val basePath = toAbsolutePath(base).normalize
+    val filePath = toAbsolutePath(file).normalize
+    if (filePath startsWith basePath) {
       val relativePath = catching(classOf[IllegalArgumentException]) opt (basePath relativize filePath)
       relativePath map (_.toString)
     } else None

--- a/io/src/test/scala/sbt/io/CopyDirectorySpec.scala
+++ b/io/src/test/scala/sbt/io/CopyDirectorySpec.scala
@@ -1,10 +1,10 @@
 package sbt.io
 
 import java.nio.file._
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.{ FlatSpec, DiagrammedAssertions }
 import sbt.io.syntax._
 
-class CopyDirectorySpec extends FlatSpec with Matchers {
+class CopyDirectorySpec extends FlatSpec with DiagrammedAssertions {
   it should "copy symlinks" in IO.withTemporaryDirectory { dir =>
     // Given:
     // src/
@@ -25,6 +25,6 @@ class CopyDirectorySpec extends FlatSpec with Matchers {
     IO.copyDirectory(dir / "src", dir / "dst")
 
     // Then: dst/lib/a.txt should have been created and have the correct contents
-    IO.read(dir / "dst" / "lib" / "a.txt") shouldBe "this is the file contents"
+    assert(IO.read(dir / "dst" / "lib" / "a.txt") == "this is the file contents")
   }
 }


### PR DESCRIPTION
Fixes #182 
See also https://github.com/sbt/io/pull/175 

The inconsisnt behavior in JDK 11 reported in #85 exposed that `IO.relativize` is currently incorrect.

The IOSpec states

```scala
IO.relativize(relativeRootDir, nestedFile).map(file) shouldBe Some(file("../../meh.file"))
```

however, given that the base directory is `/tmp/io-relativize/inside-dir/..` and that the target to be relativized is `/tmp/io-relativize/meh.file`, the correct answer should be `"meh.file"`, not `"../../meh.file"`.

This fixes the problem by avoiding the call to `getCanonicalFile`, which has the side effect of resolving symbolic links.