### PR TITLE
Fixes IO.relativize's handling of symbolic links

### DIFF
--- a/io/src/test/scala/sbt/io/CopyDirectorySpec.scala
+++ b/io/src/test/scala/sbt/io/CopyDirectorySpec.scala
@@ -1,10 +1,10 @@
 package sbt.io
 
 import java.nio.file._
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.{ FlatSpec, DiagrammedAssertions }
 import sbt.io.syntax._
 
-class CopyDirectorySpec extends FlatSpec with Matchers {
+class CopyDirectorySpec extends FlatSpec with DiagrammedAssertions {
   it should "copy symlinks" in IO.withTemporaryDirectory { dir =>
     // Given:
     // src/
@@ -25,6 +25,6 @@ class CopyDirectorySpec extends FlatSpec with Matchers {
     IO.copyDirectory(dir / "src", dir / "dst")
 
     // Then: dst/lib/a.txt should have been created and have the correct contents
-    IO.read(dir / "dst" / "lib" / "a.txt") shouldBe "this is the file contents"
+    assert(IO.read(dir / "dst" / "lib" / "a.txt") == "this is the file contents")
   }
 }

--- a/io/src/test/scala/sbt/io/IOSpec.scala
+++ b/io/src/test/scala/sbt/io/IOSpec.scala
@@ -2,10 +2,11 @@ package sbt.io
 
 import java.io.File
 import java.nio.file.Files
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.FlatSpec
 import sbt.io.syntax._
 
-class IOSpec extends FlatSpec with Matchers {
+class IOSpec extends FlatSpec {
+
   "IO" should "relativize" in {
     // Given:
     // io-relativize/
@@ -15,14 +16,17 @@ class IOSpec extends FlatSpec with Matchers {
     // and
     // relativeRootDir referring to io-relativize/inside-dir/../
 
-    val rootDir = Files.createTempDirectory("io-relativize")
+    val rootDir = Files.createTempDirectory("io-relativize").normalize
     val nestedFile = Files.createFile(rootDir resolve "meh.file").toFile
     val nestedDir = Files.createDirectory(rootDir resolve "inside-dir").toFile
 
     val relativeRootDir = new File(nestedDir, "..")
-
-    IO.relativize(rootDir.toFile, nestedFile).map(file) shouldBe Some(file("meh.file"))
-    IO.relativize(relativeRootDir, nestedFile).map(file) shouldBe Some(file("meh.file"))
+    assert(
+      IO.relativize(rootDir.toFile, nestedFile)
+        .map(normalizeForWindows) === Option("meh.file"))
+    assert(
+      IO.relativize(relativeRootDir, nestedFile).map(normalizeForWindows) === Option("meh.file"))
+    IO.delete(rootDir.toFile)
   }
 
   it should "relativize . dirs" in {
@@ -31,15 +35,15 @@ class IOSpec extends FlatSpec with Matchers {
     val file2 = new File(".", ".git")
     val file3 = new File(base, ".git")
 
-    IO.relativize(base, file1) shouldBe Some(".git")
-    IO.relativize(base, file2) shouldBe Some(".git")
-    IO.relativize(base, file3) shouldBe Some(".git")
+    assert(IO.relativize(base, file1) == Some(".git"))
+    assert(IO.relativize(base, file2) == Some(".git"))
+    assert(IO.relativize(base, file3) == Some(".git"))
   }
 
   it should "relativize relative paths" in {
     val base = new File(".").getCanonicalFile
     val file = new File("build.sbt")
-    IO.relativize(base, file) shouldBe Some("build.sbt")
+    assert(IO.relativize(base, file) == Some("build.sbt"))
   }
 
   "toURI" should "make URI" in {
@@ -64,5 +68,9 @@ class IOSpec extends FlatSpec with Matchers {
 
   "getModifiedTimeOrZero" should "return 0L if the file doesn't exists" in {
     assert(IO.getModifiedTimeOrZero(file("/not/existing/path")) == 0L)
+  }
+
+  def normalizeForWindows(s: String): String = {
+    s.replaceAllLiterally("""\""", "/")
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.3


### PR DESCRIPTION
Backport of https://github.com/sbt/io/pull/183

Fixes #182 
See also https://github.com/sbt/io/pull/175 

The inconsistent behavior in JDK 11 reported in #85 exposed that `IO.relativize` is currently incorrect.

The IOSpec states

```scala
IO.relativize(relativeRootDir, nestedFile).map(file) shouldBe Some(file("../../meh.file"))
```

however, given that the base directory is `/tmp/io-relativize/inside-dir/..` and that the target to be relativized is `/tmp/io-relativize/meh.file`, the correct answer should be `"meh.file"`, not `"../../meh.file"`.

This fixes the problem by avoiding the call to `getCanonicalFile`, which has the side effect of resolving symbolic links.