### PR TITLE
Restore IO.classfileLocation behavior

### DIFF
--- a/io/src/main/scala/sbt/io/Using.scala
+++ b/io/src/main/scala/sbt/io/Using.scala
@@ -37,7 +37,10 @@ private[sbt] abstract class WrapUsing[Source, T](
 private[sbt] trait OpenFile[T] extends Using[File, T] {
   protected def openImpl(file: File): T
   protected final def open(file: File): T = {
-    val parent = file.getParentFile
+    val parent: File = (file.toString match {
+      case f if f contains "jar!" => IO.urlAsFile(file.toURI.toURL).getOrElse(file)
+      case _                      => file
+    }).getParentFile
     if (parent != null)
       IO.createDirectory(parent)
     openImpl(file)

--- a/io/src/test/scala/sbt/io/IOSpecification.scala
+++ b/io/src/test/scala/sbt/io/IOSpecification.scala
@@ -12,8 +12,8 @@ object IOSpecification extends Properties("IO") {
           Files.isRegularFile(jar)
         case jrt if jrt.toUri.getScheme == "jrt" =>
           jrt.toString.contains("/java.base")
-        case dir =>
-          Files.isDirectory(dir)
+        case f =>
+          f.endsWith(c.getName.replaceAll("\\.", "/") + ".class")
       }
   }
 


### PR DESCRIPTION
The scripted tests fail for sbt when run against io/develop. This is
because zinc expects that IO.classfileLocation returns the full path of
a class file for any class that is in a directory, not the base path of
the class file directory.