### PR TITLE
Fixes classLocation and classfileLocation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,9 @@ val io = (project in file("io"))
       Vector(scalaCompiler.value % Test, scalaCheck % Test, scalatest.value % Test)
     } ++ Vector(swovalFiles),
     libraryDependencies ++= Seq(jna, jnaPlatform),
+
+    Test / fork := true,
+
     sourceManaged in (Compile, generateContrabands) := baseDirectory.value / "src" / "main" / "contraband-scala",
     initialCommands in console += "\nimport sbt.io._, syntax._",
     mimaPreviousArtifacts := (CrossVersion partialVersion scalaVersion.value match {

--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -57,50 +57,51 @@ object IO {
   private lazy val jrtFs = FileSystems.getFileSystem(URI.create("jrt:/"))
 
   /**
-   * Returns the NIO Path to the directory or jar file containing the class file `cl`.
-   * If the location cannot be determined or it is not a file, an error is generated.
-   * Note that Java standard library classes typically do not have a location associated with them.
+   * Returns the NIO Path to the directory, Java module, or the JAR file containing the class file `cl`.
+   * If the location cannot be determined, an error is generated.
+   * Note that for JDK 11 onwards, a module will return a jrt path.
    */
   def classLocationPath(cl: Class[_]): NioPath = {
-    val u = classfileLocation(cl)
+    val u = classLocation(cl)
     val p = u.getProtocol match {
       case FileScheme => Option(toFile(u).toPath)
       case "jar"      => urlAsFile(u) map { _.toPath }
-      case "jrt"      => Option(IO.jrtFs.getPath("/modules" + u.getPath))
+      case "jrt"      => Option(IO.jrtFs.getPath(u.getPath))
       case _          => None
     }
     p.getOrElse(sys.error(s"Unable to create File from $u for $cl"))
   }
 
   /**
-   * Returns a NIO Path for the classfile containing the given class file for type `A` (as determined by an implicit Manifest).
+   * Returns a NIO Path to the directory, Java module, or the JAR file for type `A` (as determined by an implicit Manifest).
    * If the location cannot be determined, an error is generated.
+   * Note that for JDK 11 onwards, a module will return a jrt path.
    */
   def classLocationPath[A](implicit mf: SManifest[A]): NioPath =
     classLocationPath(mf.runtimeClass)
 
   /**
-   * Returns the directory or jar file containing the class file `cl`.
+   * Returns the directory, Java module, or the JAR containing the class file `cl`.
    * If the location cannot be determined or it is not a file, an error is generated.
-   * Note that Java standard library classes typically do not have a location associated with them.
+   * Note that for JDK 11 onwards, the returned module path cannot be expressed as `File`, so it will return `None`.
    */
   def classLocationFileOption(cl: Class[_]): Option[File] = {
-    val u = classfileLocation(cl)
+    val u = classLocation(cl)
     urlAsFile(u)
   }
 
   /**
-   * Returns the directory or jar file containing the class file for type `T` (as determined by an implicit Manifest).
-   * If the location cannot be determined, an error is generated.
-   * Note that Java standard library classes typically do not have a location associated with them.
+   * Returns the directory, Java module, or the JAR containing the class file for type `T` (as determined by an implicit Manifest).
+   * If the location cannot be determined or it is not a file, an error is generated.
+   * Note that for JDK 11 onwards, the returned module path cannot be expressed as `File`, so it will return `None`.
    */
   def classLocationFileOption[A](implicit mf: SManifest[A]): Option[File] =
     classLocationFileOption(mf.runtimeClass)
 
   /**
-   * Returns the directory or jar file containing the class file `cl`.
+   * Returns the directory, Java module, or the JAR file containing the class file `cl`.
    * If the location cannot be determined or it is not a file, an error is generated.
-   * Note that Java standard library classes typically do not have a location associated with them.
+   * Note that for JDK 11 onwards, the returned module path cannot be expressed as `File`.
    */
   @deprecated(
     "classLocationFile may not work on JDK 11. Use classfileLocation, classLocationFileOption, or classLocationPath instead.",
@@ -109,14 +110,67 @@ object IO {
     classLocationFileOption(cl).getOrElse(sys.error(s"Unable to create File from $cl"))
 
   /**
-   * Returns the directory or jar file containing the class file for type `T` (as determined by an implicit Manifest).
+   * Returns the directory, Java module, or the JAR file containing the class file for type `T` (as determined by an implicit Manifest).
    * If the location cannot be determined, an error is generated.
-   * Note that Java standard library classes typically do not have a location associated with them.
+   * Note that for JDK 11 onwards, the returned module path cannot be expressed as `File`.
    */
   @deprecated(
     "classLocationFile may not work on JDK 11. Use classfileLocation, classLocationFileOption, or classLocationPath instead.",
     "1.3.0")
   def classLocationFile[T](implicit mf: SManifest[T]): File = classLocationFile(mf.runtimeClass)
+
+  /**
+   * Returns the URL to the directory, Java module, or the JAR file containing the class file `cl`.
+   * If the location cannot be determined or it is not a file, an error is generated.
+   * Note that for JDK 11 onwards, a module will return a jrt URL such as `jrt:/java.base`.
+   */
+  def classLocation(cl: Class[_]): URL = {
+    def localcl: Option[URL] =
+      Option(cl.getProtectionDomain.getCodeSource) flatMap { codeSource =>
+        Option(codeSource.getLocation)
+      }
+    // This assumes that classes without code sources are System classes, and thus located in jars.
+    // It returns a URL that looks like jar:file:/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/rt.jar!/java/lang/Integer.class
+    val clsfile = s"${cl.getName.replace('.', '/')}.class"
+    def syscl: Option[URL] =
+      Option(ClassLoader.getSystemClassLoader) flatMap { classLoader =>
+        Option(classLoader.getResource(clsfile))
+      }
+    try {
+      localcl
+        .orElse(syscl)
+        .map(url =>
+          url.getProtocol match {
+            case "jar" =>
+              val path = url.getPath
+              val end = path.indexOf('!')
+              new URL(
+                if (end == -1) path
+                else path.substring(0, end))
+            case "jrt" =>
+              val path = url.getPath
+              val end = path.indexOf('/', 1)
+              new URL("jrt",
+                      null,
+                      if (end == -1) path
+                      else path.substring(0, end))
+            case _ => url
+        })
+        .getOrElse(sys.error("No class location for " + cl))
+    } catch {
+      case NonFatal(e) =>
+        e.printStackTrace()
+        throw e
+    }
+  }
+
+  /**
+   * Returns the URL to the directory, Java module, or the JAR file containing the class file `cl`.
+   * If the location cannot be determined or it is not a file, an error is generated.
+   * Note that for JDK 11 onwards, a module will return a jrt path.
+   */
+  def classLocation[A](implicit mf: SManifest[A]): URL =
+    classLocation(mf.runtimeClass)
 
   /**
    * Returns a URL for the classfile containing the given class file for type `T` (as determined by an implicit Manifest).
@@ -131,8 +185,8 @@ object IO {
   def classfileLocation(cl: Class[_]): URL = {
     val clsfile = s"${cl.getName.replace('.', '/')}.class"
     def localcl: Option[URL] =
-      Option(cl.getProtectionDomain.getCodeSource) flatMap { codeSource =>
-        Option(codeSource.getLocation)
+      Option(cl.getClassLoader) flatMap { classLoader =>
+        Option(classLoader.getResource(clsfile))
       }
     def syscl: Option[URL] =
       Option(ClassLoader.getSystemClassLoader) flatMap { classLoader =>

--- a/io/src/test/scala/sbt/io/FileUtilitiesSpecification.scala
+++ b/io/src/test/scala/sbt/io/FileUtilitiesSpecification.scala
@@ -7,6 +7,8 @@ import java.io.File
 import org.scalacheck._, Arbitrary.arbitrary, Prop._
 
 object WriteContentSpecification extends Properties("Write content") {
+  sys.props.put("jna.nosys", "true")
+
   property("Round trip string") = forAll(writeAndCheckString _)
   property("Round trip bytes") = forAll(writeAndCheckBytes _)
   property("Write string overwrites") = forAll(overwriteAndCheckStrings _)

--- a/io/src/test/scala/sbt/io/IOSpec.scala
+++ b/io/src/test/scala/sbt/io/IOSpec.scala
@@ -2,12 +2,12 @@ package sbt.io
 
 import java.io.File
 import java.nio.file.Files
-import org.scalatest.FlatSpec
+import org.scalatest.FunSuite
 import sbt.io.syntax._
 
-class IOSpec extends FlatSpec {
+class IOSpec extends FunSuite {
 
-  "IO" should "relativize" in {
+  test("IO should relativize") {
     // Given:
     // io-relativize/
     //     meh.file
@@ -29,7 +29,7 @@ class IOSpec extends FlatSpec {
     IO.delete(rootDir.toFile)
   }
 
-  it should "relativize . dirs" in {
+  test("it should relativize . dirs") {
     val base = new File(".")
     val file1 = new File("./.git")
     val file2 = new File(".", ".git")
@@ -40,33 +40,33 @@ class IOSpec extends FlatSpec {
     assert(IO.relativize(base, file3) == Some(".git"))
   }
 
-  it should "relativize relative paths" in {
+  test("it should relativize relative paths") {
     val base = new File(".").getCanonicalFile
     val file = new File("build.sbt")
     assert(IO.relativize(base, file) == Some("build.sbt"))
   }
 
-  "toURI" should "make URI" in {
+  test("toURI should make URI") {
     val u = IO.toURI(file("/etc/hosts").getAbsoluteFile)
     assert(u.toString.startsWith("file:///") && u.toString.endsWith("etc/hosts"))
   }
 
-  it should "make u0 URI from a relative path" in {
+  test("it should make u0 URI from a relative path") {
     val u = IO.toURI(file("src") / "main" / "scala")
     assert(u.toString == "src/main/scala")
   }
 
-  it should "make URI that roundtrips" in {
+  test("it should make URI that roundtrips") {
     val u = IO.toURI(file("/etc/hosts").getAbsoluteFile)
     assert(IO.toFile(u) == file("/etc/hosts").getAbsoluteFile)
   }
 
-  it should "make u0 URI that roundtrips" in {
+  test("it should make u0 URI that roundtrips") {
     val u = IO.toURI(file("src") / "main" / "scala")
     assert(IO.toFile(u) == (file("src") / "main" / "scala"))
   }
 
-  "getModifiedTimeOrZero" should "return 0L if the file doesn't exists" in {
+  test("getModifiedTimeOrZero should return 0L if the file doesn't exists") {
     assert(IO.getModifiedTimeOrZero(file("/not/existing/path")) == 0L)
   }
 


### PR DESCRIPTION
This fixes classLocation family of methods and classfileLocation that were broken in #181.
Ref https://github.com/sbt/io/pull/188
