### PR TITLE
[1.2.x] Fixes classLocation and classfileLocation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,9 @@ val io = (project in file("io"))
       Vector(scalaCompiler.value % Test, scalaCheck % Test, scalatest.value % Test)
     } ++ Vector(appleFileEvents),
     libraryDependencies ++= Seq(jna, jnaPlatform),
+
+    Test / fork := true,
+
     sourceManaged in (Compile, generateContrabands) := baseDirectory.value / "src" / "main" / "contraband-scala",
     initialCommands in console += "\nimport sbt.io._, syntax._",
     mimaPreviousArtifacts := (CrossVersion partialVersion scalaVersion.value match {

--- a/io/src/test/scala/sbt/io/FileUtilitiesSpecification.scala
+++ b/io/src/test/scala/sbt/io/FileUtilitiesSpecification.scala
@@ -7,6 +7,8 @@ import java.io.File
 import org.scalacheck._, Arbitrary.arbitrary, Prop._
 
 object WriteContentSpecification extends Properties("Write content") {
+  sys.props.put("jna.nosys", "true")
+
   property("Round trip string") = forAll(writeAndCheckString _)
   property("Round trip bytes") = forAll(writeAndCheckBytes _)
   property("Write string overwrites") = forAll(overwriteAndCheckStrings _)

--- a/io/src/test/scala/sbt/io/IOSpec.scala
+++ b/io/src/test/scala/sbt/io/IOSpec.scala
@@ -2,12 +2,12 @@ package sbt.io
 
 import java.io.File
 import java.nio.file.Files
-import org.scalatest.FlatSpec
+import org.scalatest.FunSuite
 import sbt.io.syntax._
 
-class IOSpec extends FlatSpec {
+class IOSpec extends FunSuite {
 
-  "IO" should "relativize" in {
+  test("IO should relativize") {
     // Given:
     // io-relativize/
     //     meh.file
@@ -29,7 +29,7 @@ class IOSpec extends FlatSpec {
     IO.delete(rootDir.toFile)
   }
 
-  it should "relativize . dirs" in {
+  test("it should relativize . dirs") {
     val base = new File(".")
     val file1 = new File("./.git")
     val file2 = new File(".", ".git")
@@ -40,33 +40,33 @@ class IOSpec extends FlatSpec {
     assert(IO.relativize(base, file3) == Some(".git"))
   }
 
-  it should "relativize relative paths" in {
+  test("it should relativize relative paths") {
     val base = new File(".").getCanonicalFile
     val file = new File("build.sbt")
     assert(IO.relativize(base, file) == Some("build.sbt"))
   }
 
-  "toURI" should "make URI" in {
+  test("toURI should make URI") {
     val u = IO.toURI(file("/etc/hosts").getAbsoluteFile)
     assert(u.toString.startsWith("file:///") && u.toString.endsWith("etc/hosts"))
   }
 
-  it should "make u0 URI from a relative path" in {
+  test("it should make u0 URI from a relative path") {
     val u = IO.toURI(file("src") / "main" / "scala")
     assert(u.toString == "src/main/scala")
   }
 
-  it should "make URI that roundtrips" in {
+  test("it should make URI that roundtrips") {
     val u = IO.toURI(file("/etc/hosts").getAbsoluteFile)
     assert(IO.toFile(u) == file("/etc/hosts").getAbsoluteFile)
   }
 
-  it should "make u0 URI that roundtrips" in {
+  test("it should make u0 URI that roundtrips") {
     val u = IO.toURI(file("src") / "main" / "scala")
     assert(IO.toFile(u) == (file("src") / "main" / "scala"))
   }
 
-  "getModifiedTimeOrZero" should "return 0L if the file doesn't exists" in {
+  test("getModifiedTimeOrZero should return 0L if the file doesn't exists") {
     assert(IO.getModifiedTimeOrZero(file("/not/existing/path")) == 0L)
   }
 


### PR DESCRIPTION
This is a backport of https://github.com/sbt/io/pull/189

On JDK 11 onwards the class location from a Java Module returns a jrt URL, for example `jrt:/java.base`, which cannot convert to `java.io.File`, but can be represented as an NIO `Path`.

To work around this, sbt 1.2.4:
- deprecates `IO.classLocationFile[A: Manifest]: File`
- brings back `IO.classLocation[A: Manifest]: URL`
- adds `IO.classLocationPath[A: Manifest]: java.nio.file.Path` and `IO.classLocationFileOption[A: Manifest]: Option[File]`.

All of them return the directory, Java module, or the JAR containing the class file for type `A` (as determined by an implicit `Manifest`).