### PR TITLE
Rename sbt.io.Logger sbt.io.WatchLogger

### DIFF
--- a/io/src/main/scala/sbt/internal/io/EventMonitor.scala
+++ b/io/src/main/scala/sbt/internal/io/EventMonitor.scala
@@ -55,7 +55,7 @@ private[sbt] object EventMonitor {
             antiEntropy: FiniteDuration,
             terminationCondition: => Boolean,
             logger: Logger = NullLogger): EventMonitor = {
-    val eventLogger = new io.Logger {
+    val eventLogger = new io.WatchLogger {
       override def debug(msg: => Any): Unit = logger.debug(msg)
     }
     val observable = new WatchServiceBackedObservable[Path](watchState,

--- a/io/src/main/scala/sbt/internal/io/HybridPollingFileRepository.scala
+++ b/io/src/main/scala/sbt/internal/io/HybridPollingFileRepository.scala
@@ -23,7 +23,7 @@ private[sbt] trait HybridPollingFileRepository[+T] extends FileRepository[T] { s
   def shouldPoll(source: Source): Boolean = shouldPoll(source.base.toPath)
   def toPollingObservable(delay: FiniteDuration,
                           sources: Seq[Source],
-                          logger: Logger): Observable[T]
+                          logger: WatchLogger): Observable[T]
 }
 
 private[io] case class HybridPollingFileRepositoryImpl[+T](converter: TypedPath => T,
@@ -81,7 +81,7 @@ private[io] case class HybridPollingFileRepositoryImpl[+T](converter: TypedPath 
   }
   def toPollingObservable(delay: FiniteDuration,
                           sources: Seq[Source],
-                          logger: Logger): Observable[T] = {
+                          logger: WatchLogger): Observable[T] = {
     val pollingSources = sources.filter(shouldPoll)
     if (pollingSources.isEmpty) self
     else {

--- a/io/src/main/scala/sbt/internal/io/SourceModificationWatch.scala
+++ b/io/src/main/scala/sbt/internal/io/SourceModificationWatch.scala
@@ -32,8 +32,8 @@ private[sbt] object SourceModificationWatch {
                                                               delay,
                                                               (_: TypedPath).getPath,
                                                               closeService = false,
-                                                              NullLogger)
-      val monitor = FileEventMonitor.antiEntropy(observable, 200.milliseconds, NullLogger)
+                                                              NullWatchLogger)
+      val monitor = FileEventMonitor.antiEntropy(observable, 200.milliseconds, NullWatchLogger)
       @tailrec
       def poll(): Boolean = {
         monitor.poll(10.millis) match {

--- a/io/src/main/scala/sbt/internal/io/WatchServiceBackedObservable.scala
+++ b/io/src/main/scala/sbt/internal/io/WatchServiceBackedObservable.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.{ CountDownLatch, TimeUnit }
 
 import sbt.io.FileTreeDataView.{ Entry, Observable }
 import sbt.io.FileTreeView.AllPass
-import sbt.io.{ FileTreeDataView, FileTreeView, Logger, TypedPath }
+import sbt.io.{ FileTreeDataView, FileTreeView, WatchLogger, TypedPath }
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
@@ -22,7 +22,7 @@ private[sbt] class WatchServiceBackedObservable[+T](s: WatchState,
                                                     delay: FiniteDuration,
                                                     converter: TypedPath => T,
                                                     closeService: Boolean,
-                                                    logger: Logger)
+                                                    logger: WatchLogger)
     extends Observable[T] {
   private[this] val closed = new AtomicBoolean(false)
   private[this] val observers = new Observers[T]

--- a/io/src/main/scala/sbt/io/FileEventMonitor.scala
+++ b/io/src/main/scala/sbt/io/FileEventMonitor.scala
@@ -64,11 +64,12 @@ object FileEventMonitor {
     override def hashCode(): Int = entry.hashCode()
   }
 
-  def apply[T](observable: Observable[T], logger: Logger = NullLogger): FileEventMonitor[T] =
+  def apply[T](observable: Observable[T],
+               logger: WatchLogger = NullWatchLogger): FileEventMonitor[T] =
     new FileEventMonitorImpl[T](observable, logger)
   def antiEntropy[T](observable: Observable[T],
                      period: FiniteDuration,
-                     logger: Logger,
+                     logger: WatchLogger,
                      quarantinePeriod: FiniteDuration = 50.millis): FileEventMonitor[T] = {
     new AntiEntropyFileEventMonitor(period,
                                     new FileEventMonitorImpl[T](observable, logger),
@@ -76,7 +77,7 @@ object FileEventMonitor {
                                     quarantinePeriod)
   }
 
-  private class FileEventMonitorImpl[T](observable: Observable[T], logger: Logger)
+  private class FileEventMonitorImpl[T](observable: Observable[T], logger: WatchLogger)
       extends FileEventMonitor[T] {
     private case object Trigger
     private val events =
@@ -162,7 +163,7 @@ object FileEventMonitor {
   }
   private class AntiEntropyFileEventMonitor[T](period: FiniteDuration,
                                                fileEventMonitor: FileEventMonitor[T],
-                                               logger: Logger,
+                                               logger: WatchLogger,
                                                quarantinePeriod: FiniteDuration)
       extends FileEventMonitor[T] {
     private[this] val recentEvents = mutable.Map.empty[JPath, Deadline]

--- a/io/src/main/scala/sbt/io/WatchLogger.scala
+++ b/io/src/main/scala/sbt/io/WatchLogger.scala
@@ -1,9 +1,9 @@
 package sbt.io
 
-private[sbt] trait Logger {
+private[sbt] trait WatchLogger {
   def debug(msg: => Any): Unit
 }
-private[sbt] object NullLogger extends Logger {
+private[sbt] object NullWatchLogger extends WatchLogger {
   private def ignoreArg[T](f: => T): Unit = if (false) { f; () } else ()
   override def debug(msg: => Any): Unit = ignoreArg(msg)
 }

--- a/io/src/test/scala/sbt/internal/io/FileEventMonitorSpec.scala
+++ b/io/src/test/scala/sbt/internal/io/FileEventMonitorSpec.scala
@@ -3,7 +3,7 @@ package sbt.internal.io
 import java.nio.file.{ Path, Paths }
 
 import org.scalatest.{ FlatSpec, Matchers }
-import sbt.io.{ FileEventMonitor, NullLogger, TypedPath }
+import sbt.io.{ FileEventMonitor, NullWatchLogger, TypedPath }
 import sbt.io.FileEventMonitor.{ Creation, Deletion, Update }
 import sbt.io.FileTreeDataView.Entry
 
@@ -30,7 +30,7 @@ class FileEventMonitorSpec extends FlatSpec with Matchers {
   "anti-entropy" should "ignore redundant events" in {
     val observers = new Observers[Path]
     val antiEntropyPeriod = 20.millis
-    val monitor = FileEventMonitor.antiEntropy(observers, antiEntropyPeriod, NullLogger)
+    val monitor = FileEventMonitor.antiEntropy(observers, antiEntropyPeriod, NullWatchLogger)
     val entry = TestEntry("foo", FILE | EXISTS)
     val start = Deadline.now
     observers.onCreate(entry)
@@ -48,7 +48,7 @@ class FileEventMonitorSpec extends FlatSpec with Matchers {
     val antiEntropyPeriod = 40.millis
     val quarantinePeriod = antiEntropyPeriod / 2
     val monitor =
-      FileEventMonitor.antiEntropy(observers, antiEntropyPeriod, NullLogger, quarantinePeriod)
+      FileEventMonitor.antiEntropy(observers, antiEntropyPeriod, NullWatchLogger, quarantinePeriod)
     val entry = TestEntry("foo", FILE)
     observers.onDelete(entry)
     monitor.poll(0.millis) shouldBe Nil
@@ -59,7 +59,7 @@ class FileEventMonitorSpec extends FlatSpec with Matchers {
     val antiEntropyPeriod = 40.millis
     val quarantinePeriod = antiEntropyPeriod / 2
     val monitor =
-      FileEventMonitor.antiEntropy(observers, antiEntropyPeriod, NullLogger, quarantinePeriod)
+      FileEventMonitor.antiEntropy(observers, antiEntropyPeriod, NullWatchLogger, quarantinePeriod)
     val deletedEntry = TestEntry("foo", FILE)
     val newEntry = TestEntry("foo", FILE | EXISTS)
     observers.onDelete(deletedEntry)

--- a/io/src/test/scala/sbt/internal/io/HybridEventMonitorSpec.scala
+++ b/io/src/test/scala/sbt/internal/io/HybridEventMonitorSpec.scala
@@ -64,7 +64,7 @@ object HybridEventMonitorSpec {
       f: FileEventMonitor[_] => T): T = {
     val monitor = observable match {
       case r: HybridPollingFileRepository[_] =>
-        FileEventMonitor(r.toPollingObservable(pollDelay, sources, NullLogger))
+        FileEventMonitor(r.toPollingObservable(pollDelay, sources, NullWatchLogger))
     }
     try {
       f(monitor)


### PR DESCRIPTION
The previous class name broke source compatibility for files that imported
both sbt.io._ and sbt.util._. Since no io version has been released with
the new class, we won't break binary compatibility by renaming it here.

Fixes #191