### PR TITLE
Rename FileRepository FileTreeRepository

### DIFF
--- a/io/src/main/scala/sbt/internal/io/FileTreeRepositoryImpl.scala
+++ b/io/src/main/scala/sbt/internal/io/FileTreeRepositoryImpl.scala
@@ -7,18 +7,20 @@ import com.swoval.files.FileTreeDataViews.Converter
 import com.swoval.files.{ FileTreeRepositories, TypedPath => STypedPath }
 import com.swoval.functional.Filters
 import sbt.internal.io.SwovalConverters.{ SwovalEitherOps, SwovalEntryOps, ObserverOps }
-import sbt.io.{ FileRepository, FileTreeDataView, TypedPath }
+import sbt.io.{ FileTreeRepository, FileTreeDataView, TypedPath }
 import FileTreeDataView.Entry
 
 import scala.collection.immutable.VectorBuilder
 
 /**
- * The default implemenation of [[FileRepository]]. It delegates all of its methods to the
+ * The default implemenation of [[FileTreeRepository]]. It delegates all of its methods to the
  * [[https://swoval.github.io/files/jvm/com/swoval/files/FileTreeRepository.html swoval FileTreeRepository]].
+ *
  * @param converter the function to convert paths to
  * @tparam T the type of the [[FileTreeDataView.Entry.value]]s.
  */
-private[sbt] class FileRepositoryImpl[+T](converter: TypedPath => T) extends FileRepository[T] {
+private[sbt] class FileTreeRepositoryImpl[+T](converter: TypedPath => T)
+    extends FileTreeRepository[T] {
   private[this] val underlying = FileTreeRepositories.get[T](new Converter[T] {
     import SwovalConverters.SwovalTypedPathOps
     override def apply(path: STypedPath): T = converter(path.asSbt)

--- a/io/src/main/scala/sbt/internal/io/HybridPollingFileTreeRepository.scala
+++ b/io/src/main/scala/sbt/internal/io/HybridPollingFileTreeRepository.scala
@@ -9,15 +9,15 @@ import sbt.io._
 import scala.concurrent.duration.FiniteDuration
 
 /**
- * A hybrid [[FileRepository]] that caches some paths and monitors them with os notifications and
+ * A hybrid [[FileTreeRepository]] that caches some paths and monitors them with os notifications and
  * does not cache the paths that are filtered using the provided shouldPoll function. As a general
  * rule, the paths to be polled should ideally not be in the same directory tree as any of the
- * paths that are being cached. The [[FileRepository.list]] method should do the right thing in this
+ * paths that are being cached. The [[FileTreeRepository.list]] method should do the right thing in this
  * case, but it's possible that there may be some bugs in handling the overlapping paths.
  *
  * @tparam T the type of the [[Entry.value]]s.
  */
-private[sbt] trait HybridPollingFileRepository[+T] extends FileRepository[T] { self =>
+private[sbt] trait HybridPollingFileTreeRepository[+T] extends FileTreeRepository[T] { self =>
   def shouldPoll(path: Path): Boolean
   def shouldPoll(typedPath: TypedPath): Boolean = shouldPoll(typedPath.getPath)
   def shouldPoll(source: Source): Boolean = shouldPoll(source.base.toPath)
@@ -26,10 +26,10 @@ private[sbt] trait HybridPollingFileRepository[+T] extends FileRepository[T] { s
                           logger: WatchLogger): Observable[T]
 }
 
-private[io] case class HybridPollingFileRepositoryImpl[+T](converter: TypedPath => T,
-                                                           pollingSources: Seq[Source])
-    extends HybridPollingFileRepository[T] { self =>
-  private val repo = new FileRepositoryImpl[T](converter)
+private[io] case class HybridPollingFileTreeRepositoryImpl[+T](converter: TypedPath => T,
+                                                               pollingSources: Seq[Source])
+    extends HybridPollingFileTreeRepository[T] { self =>
+  private val repo = new FileTreeRepositoryImpl[T](converter)
   private val view = DefaultFileTreeView.asDataView(converter)
   private val shouldPollEntry: Entry[_] => Boolean = (e: Entry[_]) => shouldPoll(e.typedPath)
 
@@ -107,7 +107,8 @@ private[io] case class HybridPollingFileRepositoryImpl[+T](converter: TypedPath 
   }
 }
 
-private[sbt] object HybridPollingFileRepository {
-  def apply[T](converter: TypedPath => T, pollingSources: Source*): HybridPollingFileRepository[T] =
-    HybridPollingFileRepositoryImpl(converter, pollingSources)
+private[sbt] object HybridPollingFileTreeRepository {
+  def apply[T](converter: TypedPath => T,
+               pollingSources: Source*): HybridPollingFileTreeRepository[T] =
+    HybridPollingFileTreeRepositoryImpl(converter, pollingSources)
 }

--- a/io/src/main/scala/sbt/io/FileTreeRepository.scala
+++ b/io/src/main/scala/sbt/io/FileTreeRepository.scala
@@ -7,8 +7,8 @@ import java.nio.file.{ Files, NoSuchFileException, Path => JPath }
 
 import sbt.internal.io.{
   DefaultFileTreeView,
-  FileRepositoryImpl,
-  HybridPollingFileRepository,
+  FileTreeRepositoryImpl,
+  HybridPollingFileTreeRepository,
   Source
 }
 import sbt.io.FileTreeDataView.{ Entry, Observable }
@@ -155,8 +155,9 @@ object FileTreeDataView {
   }
 
   /**
-   * A FileRepository observer that receives callbacks
-   * @tparam T the generic type of [[Entry.value]] instances for the [[FileRepository]]
+   * A FileTreeRepository observer that receives callbacks
+   *
+   * @tparam T the generic type of [[Entry.value]] instances for the [[FileTreeRepository]]
    */
   trait Observer[-T] {
 
@@ -260,15 +261,15 @@ object FileTreeDataView {
 
 /**
  * Monitors registered directories for file changes. A typical implementation will keep an
- * in memory cache of the file system that can be queried in [[FileRepository#listEntries]]. The
- * [[FileRepository#register]] method adds monitoring for a particular cache. A filter may be provided
+ * in memory cache of the file system that can be queried in [[FileTreeRepository#listEntries]]. The
+ * [[FileTreeRepository#register]] method adds monitoring for a particular cache. A filter may be provided
  * so that the cache doesn't waste memory on files the user doesn't care about. The
  * cache may be shared across a code base so there additional apis for adding filters or changing
  * the recursive property of a directory.
  *
  * @tparam T the type of the [[FileTreeDataView.Entry.value]]s.
  */
-trait FileRepository[+T] extends Observable[T] with FileTreeDataView[T] with AutoCloseable {
+trait FileTreeRepository[+T] extends Observable[T] with FileTreeDataView[T] with AutoCloseable {
 
   /**
    * Register a directory for monitoring
@@ -291,27 +292,29 @@ trait FileRepository[+T] extends Observable[T] with FileTreeDataView[T] with Aut
   def unregister(path: JPath): Unit
 }
 
-object FileRepository {
+object FileTreeRepository {
 
   /**
-   * Create a [[FileRepository]]. The generated repository will cache the file system tree for the
+   * Create a [[FileTreeRepository]]. The generated repository will cache the file system tree for the
    * monitored directories.
+   *
    * @param converter function to generate an [[FileTreeDataView.Entry.value]] from a [[TypedPath]]
    * @tparam T the generic type of the [[FileTreeDataView.Entry.value]]
    * @return a file repository.
    */
-  def default[T](converter: TypedPath => T): FileRepository[T] =
-    new FileRepositoryImpl[T](converter)
+  def default[T](converter: TypedPath => T): FileTreeRepository[T] =
+    new FileTreeRepositoryImpl[T](converter)
 
   /**
-   * Create a [[FileRepository]]. The generated repository will cache the file system tree for some
+   * Create a [[FileTreeRepository]]. The generated repository will cache the file system tree for some
    * of the paths under monitoring, but others will need to be polled.
+   *
    * @param converter function to generate an [[FileTreeDataView.Entry.value]] from a [[TypedPath]]
    * @param pollingSources do not cache any path contained in these [[sbt.internal.io.Source]]s.
    * @tparam T the generic type of the [[FileTreeDataView.Entry.value]]
    * @return a file repository.
    */
   def hybrid[T](converter: TypedPath => T,
-                pollingSources: Source*): HybridPollingFileRepository[T] =
-    HybridPollingFileRepository(converter, pollingSources: _*)
+                pollingSources: Source*): HybridPollingFileTreeRepository[T] =
+    HybridPollingFileTreeRepository(converter, pollingSources: _*)
 }

--- a/io/src/test/scala/sbt/internal/io/HybridEventMonitorSpec.scala
+++ b/io/src/test/scala/sbt/internal/io/HybridEventMonitorSpec.scala
@@ -14,7 +14,7 @@ class HybridEventMonitorSpec extends FlatSpec with Matchers {
     val dir = baseDir.toPath.toRealPath()
     val pollingDir = Files.createDirectory(dir.resolve("polling"))
     val monitoredDir = Files.createDirectory(dir.resolve("monitored"))
-    val repo = FileRepository.hybrid((_: TypedPath).getPath, Source(pollingDir.toFile))
+    val repo = FileTreeRepository.hybrid((_: TypedPath).getPath, Source(pollingDir.toFile))
     val sources = Seq(Source(pollingDir.toFile), Source(monitoredDir.toFile))
     repo.register(pollingDir, Integer.MAX_VALUE)
     repo.register(monitoredDir, Integer.MAX_VALUE)
@@ -63,7 +63,7 @@ object HybridEventMonitorSpec {
   def withMonitor[T](observable: Observable[_], sources: Seq[Source])(
       f: FileEventMonitor[_] => T): T = {
     val monitor = observable match {
-      case r: HybridPollingFileRepository[_] =>
+      case r: HybridPollingFileTreeRepository[_] =>
         FileEventMonitor(r.toPollingObservable(pollDelay, sources, NullWatchLogger))
     }
     try {
@@ -72,7 +72,7 @@ object HybridEventMonitorSpec {
       monitor.close()
     }
   }
-  implicit class FileRepositoryOps[+T](val fileRepository: FileRepository[T]) {
+  implicit class FileRepositoryOps[+T](val fileRepository: FileTreeRepository[T]) {
     def ls(path: Path): Seq[Path] =
       fileRepository.list(path, Integer.MAX_VALUE, (_: TypedPath) => true).map(_.getPath)
   }

--- a/io/src/test/scala/sbt/internal/io/HybridPollingFileTreeRepositorySpec.scala
+++ b/io/src/test/scala/sbt/internal/io/HybridPollingFileTreeRepositorySpec.scala
@@ -4,18 +4,18 @@ import java.nio.file.{ Files, Path }
 import java.util.concurrent.{ CountDownLatch, TimeUnit }
 
 import org.scalatest.{ FlatSpec, Matchers }
-import sbt.io.FileRepositorySpec.FileRepositoryOps
+import sbt.io.FileTreeRepositorySpec.FileRepositoryOps
 import sbt.io.FileTreeDataView.Observer
 import sbt.io._
 
-class HybridPollingFileRepositorySpec extends FlatSpec with Matchers {
+class HybridPollingFileTreeRepositorySpec extends FlatSpec with Matchers {
   val allPass: TypedPath => Boolean = (_: TypedPath) => true
   it should "poll specified directories " in IO.withTemporaryDirectory { baseDir =>
     val dir = Files.createDirectory(baseDir.toPath.resolve("regular")).toRealPath()
     val pollingDir = Files.createDirectory(baseDir.toPath.resolve("polling")).toRealPath()
     val latch = new CountDownLatch(1)
     val repo =
-      FileRepository.hybrid((_: TypedPath).getPath, Source(pollingDir.toFile))
+      FileTreeRepository.hybrid((_: TypedPath).getPath, Source(pollingDir.toFile))
     try {
       repo.register(dir, maxDepth = Integer.MAX_VALUE)
       repo.register(pollingDir, maxDepth = Integer.MAX_VALUE)
@@ -53,7 +53,8 @@ class HybridPollingFileRepositorySpec extends FlatSpec with Matchers {
     val file = Files.createFile(nested.resolve("file"))
     val filter: FileFilter = new SimpleFileFilter(_.getName != subdir.toFile.getName)
     val repo =
-      FileRepository.hybrid((_: TypedPath).getPath, Source(subdir.toFile, filter, NothingFilter))
+      FileTreeRepository.hybrid((_: TypedPath).getPath,
+                                Source(subdir.toFile, filter, NothingFilter))
     try {
       repo.register(dir, Integer.MAX_VALUE)
       repo.ls(dir).sorted shouldBe Seq(subdir, nested, file)

--- a/io/src/test/scala/sbt/internal/io/SourceModificationWatchSpec.scala
+++ b/io/src/test/scala/sbt/internal/io/SourceModificationWatchSpec.scala
@@ -489,11 +489,11 @@ object EventMonitorSpec {
   }
 }
 
-class FileRepositoryEventMonitorSpec extends FlatSpec with Matchers with EventMonitorSpec {
+class FileTreeRepositoryEventMonitorSpec extends FlatSpec with Matchers with EventMonitorSpec {
   override def pollDelay: FiniteDuration = 100.millis
 
   override def newObservable(sources: Seq[Source]): Observable[_] = {
-    val repository = FileRepository.default((_: TypedPath).getPath)
+    val repository = FileTreeRepository.default((_: TypedPath).getPath)
     sources foreach (s =>
       repository.register(s.base.toPath, if (s.recursive) Integer.MAX_VALUE else 0))
     repository.filter(e => sources.exists(s => s.accept(e.typedPath.getPath)))


### PR DESCRIPTION
This name both matches swoval and doesn't conflict with
sbt.librarymanagement.FileRepository. Since there hasn't been a 1.3.x
release yet, there are no binary compatibility issues with the rename.