### PR TITLE
Catch all IOExceptions in swoval pathfinder implementation

### DIFF
--- a/io/src/main/scala/sbt/io/Path.scala
+++ b/io/src/main/scala/sbt/io/Path.scala
@@ -13,8 +13,6 @@ import java.nio.file.{
   FileVisitor,
   Files,
   LinkOption,
-  NoSuchFileException,
-  NotDirectoryException,
   Path => NioPath
 }
 
@@ -502,7 +500,7 @@ private object DescendantOrSelfPathFinder {
         )
       ()
     } catch {
-      case _: NotDirectoryException | _: NoSuchFileException =>
+      case _: IOException =>
     }
   }
   def nio(file: File, filter: FileFilter, fileSet: mutable.Set[File]): Unit = {


### PR DESCRIPTION
The appveyor build failed when run against 1.3.0-M1 because of an
AccessDeniedException thrown by the native swoval pathfinder
implementation.