### PR TITLE
Bump swoval

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,5 +13,5 @@ object Dependencies {
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.6-SNAP3"
   val jna = "net.java.dev.jna" % "jna" % "4.5.0"
   val jnaPlatform = "net.java.dev.jna" % "jna-platform" % "4.5.0"
-  val swovalFiles = "com.swoval" % "file-tree-views" % "2.0.3"
+  val swovalFiles = "com.swoval" % "file-tree-views" % "2.0.4"
 }


### PR DESCRIPTION
I found a bug where sometimes the FileTreeRepository would not load some
directories in multi-project builds which would lead to compilation
failing due to missing source files. It was an upstream bug in the
swoval library that I fixed in
https://github.com/swoval/swoval/commit/72e986240a792807d9e1fa9f89d2e39a84bd3224