### PR TITLE
Don't use system provided sbt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
-language: scala
+language: java
 
 env:
   global:
-  - SBT_VER=1.1.2
+  - TRAVIS_SCALA_VERSION=2.12.7
+  - SBT_VER=1.2.4
   - secure: HFp0Jm4r+bk7CKT5YJX6rlqo0+itHfcae0gC4BY7rNrv8JN7POHs+Db2BeCwwOJXKFxHDxFjLyKwzX4LcFkBzQataUfzqHvBlkLh2XkCkMUZsOt4xhflwJZMXYihLyoX0Wct42AE4DWmBiFiC5wePI6/7/nWFk+gv0KN+X8zK0y1WdtZR6PqyFxE0NengnRB9sliiDQU2ESdZ7zuoMytbRDlcmTqj70C8ym9KGLdZvM/8R7n+5GGbkfvCXAiNnYDd2uARw/Ep4JDqM/UoXC21NqOknIHuaC3j3Rb66+wgNev+Nmfg5YU1mGWWGWSsFPTh6MVuUM84aFtoStUwsTSjvVvHTrzPyHEg4kP44Qco5fdRgDQUz+7MVOjVL4hogW0eLSiVceOle7tcN6Q5zn/5wNaKoJRJjo9Dw5zEI+w4AgEkiky/TKRnJQiqzTbLQ2kN9ALGJAHan1+Kg7SaC5GWdjm6bDFz4zjbAPYEqPosePRB9X2sxUjndTE/HYLgLLqK5yIUj06XY7YNmWOwRS83+5VzwAl82lkfaI9oXb8Giy7XiAtT0jfviAHwSx1fo1QRyBUCCPyxiLccgFLCFyaUBwwUXXBEieWJWLbRIbScj3b0RTZRtR/VZ54rz3rMzDxD9J09x7NGJvn3Ext0ampMuOcJpEHOy2akojZ60qQcV8=
 
 matrix:
   include:
    - scala: 2.10.7
-     env: CMD="mimaReportBinaryIssues scalafmt::test test:scalafmt::test sbt:scalafmt::test test"
+     env:
+         CMD="mimaReportBinaryIssues scalafmt::test test:scalafmt::test sbt:scalafmt::test test"
+         TRAVIS_SCALA_VERSION=2.10.7
      os: linux
      dist: trusty
 
@@ -21,7 +24,9 @@ matrix:
      osx_image: xcode9.3
 
    - scala: 2.11.12
-     env: CMD="mimaReportBinaryIssues scalafmt::test test:scalafmt::test sbt:scalafmt::test test"
+     env:
+       CMD="mimaReportBinaryIssues scalafmt::test test:scalafmt::test sbt:scalafmt::test test"
+       TRAVIS_SCALA_VERSION=2.11.12
      os: linux
      dist: trusty
 
@@ -34,12 +39,16 @@ matrix:
      osx_image: xcode9.3
 
    - scala: 2.12.7
-     env: CMD="mimaReportBinaryIssues scalafmt::test test:scalafmt::test sbt:scalafmt::test test whitesourceCheckPolicies"
+     env:
+         CMD="mimaReportBinaryIssues scalafmt::test test:scalafmt::test sbt:scalafmt::test test whitesourceCheckPolicies"
+         TRAVIS_SCALA_VERSION=2.12.7
      os: linux
      dist: trusty
 
    - scala: 2.12.7
-     env: CMD="mimaReportBinaryIssues scalafmt::test test:scalafmt::test sbt:scalafmt::test test"
+     env:
+         CMD="mimaReportBinaryIssues scalafmt::test test:scalafmt::test sbt:scalafmt::test test"
+         TRAVIS_SCALA_VERSION=2.12.7
      os: linux
      dist: trusty
      jdk: openjdk11
@@ -67,15 +76,15 @@ matrix:
      language: java
      osx_image: xcode9.3
 
-script: sbt -Dsbt.version=$SBT_VER ++$TRAVIS_SCALA_VERSION $CMD
+script: /tmp/sbt/bin/sbt -Dsbt.version=$SBT_VER ++$TRAVIS_SCALA_VERSION $CMD
 
 before_install:
   # https://github.com/travis-ci/travis-ci/issues/8408
   - unset _JAVA_OPTIONS
-  - if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then
-      brew update;
-      brew install sbt;
-    fi
+  - wget https://github.com/sbt/sbt/releases/download/v$SBT_VER/sbt-$SBT_VER.tgz;
+  - tar -xvf sbt-$SBT_VER.tgz;
+  - rm sbt-$SBT_VER.tgz;
+  - mv sbt /tmp/sbt;
 
 cache:
   directories:


### PR DESCRIPTION
It takes ages to update homebrew on travis (3-4 minutes), so we can
speed up the build by just downloading the sbt version we want
directly.