### PR TITLE
Improve NameFilters

### DIFF
--- a/io/src/main/scala/sbt/internal/io/SourceModificationWatch.scala
+++ b/io/src/main/scala/sbt/internal/io/SourceModificationWatch.scala
@@ -168,6 +168,13 @@ final class Source(
        |  recursive = $recursive,
        |)""".stripMargin
 
+  override def equals(o: Any): Boolean = o match {
+    case that: Source =>
+      this.base == that.base && this.includeFilter == that.includeFilter &&
+        this.excludeFilter == that.excludeFilter && this.recursive == that.recursive
+    case _ => false
+  }
+  override lazy val hashCode: Int = Seq[Any](base, includeFilter, excludeFilter, recursive).hashCode
 }
 
 object Source {

--- a/io/src/test/scala/sbt/internal/io/SourceSpec.scala
+++ b/io/src/test/scala/sbt/internal/io/SourceSpec.scala
@@ -31,4 +31,21 @@ class SourceSpec extends FlatSpec with Matchers {
     source.accept(Paths.get("/foo/bar/baz.scala")) shouldBe true
     source.accept(Paths.get("/foo/bar/buzz.scala")) shouldBe false
   }
+  it should "override equals/hashcode" in {
+    val source = new Source(new File("foo"), AllPassFilter, NothingFilter, true)
+    val copy = new Source(new File("foo"), AllPassFilter, NothingFilter, true)
+    assert(source == copy && copy == source)
+    assert(source.hashCode == copy.hashCode)
+    val others = Seq(
+      new Source(new File("bar"), AllPassFilter, NothingFilter, true),
+      new Source(new File("foo"), NothingFilter, NothingFilter, true),
+      new Source(new File("foo"), AllPassFilter, AllPassFilter, true),
+      new Source(new File("foo"), AllPassFilter, NothingFilter, false),
+      new Object
+    )
+    others foreach { src =>
+      assert(source != src && src != source)
+      assert(source.hashCode != src.hashCode)
+    }
+  }
 }

--- a/io/src/test/scala/sbt/io/CombinedFilterSpec.scala
+++ b/io/src/test/scala/sbt/io/CombinedFilterSpec.scala
@@ -1,0 +1,67 @@
+package sbt.io
+import java.io.File
+
+import org.scalatest.{ FlatSpec, Matchers }
+
+class CombinedFilterSpec extends FlatSpec with Matchers {
+  def endsWithTxt: String => Boolean = new Function[String, Boolean] {
+    override def apply(string: String): Boolean = string.endsWith("txt")
+  }
+  "FileFilter" should "combine filters with &&" in IO.withTemporaryDirectory { dir =>
+    val firstFilter = new ExactFilter(dir.getName)
+    assert(firstFilter.accept(dir))
+    val andFilter = firstFilter && DirectoryFilter
+    assert(andFilter.accept(dir))
+    assert(andFilter.toString == s"$firstFilter && DirectoryFilter")
+  }
+  it should "combine filters with &" in IO.withTemporaryDirectory { dir =>
+    val file = new File(dir, "foo.txt")
+    val firstFilter = new ExactFilter("foo.txt")
+    assert(firstFilter.accept(file))
+    val endsWith = endsWithTxt
+    val andFilter = firstFilter && new SimpleFilter(endsWith)
+    assert(andFilter.accept(file))
+    // This is subtle. I'm checking that equality works when the same function instance is used
+    // in the SimpleFilter, but a new SimpleFilter is created itself. In the second test case,
+    // equality doesn't work because endsWithText creates a new instance of String => Boolean
+    // which can't be equal to the endsWithText local variable.
+    assert(andFilter == (firstFilter && new SimpleFilter(endsWith)))
+    assert(andFilter != (firstFilter && new SimpleFilter(endsWithTxt)))
+  }
+  it should "combine filters with ||" in IO.withTemporaryDirectory { dir =>
+    val firstFilter = new ExactFilter("foo.txt")
+    assert(!firstFilter.accept(dir))
+    val orFilter = firstFilter || DirectoryFilter
+    assert(orFilter.accept(dir))
+    assert(orFilter.toString == s"ExactFilter(foo.txt) || DirectoryFilter")
+  }
+  it should "combine filters with |" in IO.withTemporaryDirectory { dir =>
+    val file = new File("bar.txt")
+    val firstFilter = new ExactFilter("foo.txt")
+    assert(!firstFilter.accept(file))
+    val orFilter = firstFilter | new ExactFilter("bar.txt")
+    assert(orFilter.accept(file))
+  }
+  it should "combine filters with --" in IO.withTemporaryDirectory { dir =>
+    val firstFilter = new ExactFilter(dir.getName)
+    assert(firstFilter.accept(dir.getName))
+    val andNotFilter = firstFilter -- DirectoryFilter
+    assert(!andNotFilter.accept(dir))
+    assert(andNotFilter.toString == s"ExactFilter(${dir.getName}) && !DirectoryFilter")
+  }
+  it should "combine filters with -" in {
+    val file = new File("foo.scala")
+    val firstFilter = new ExactFilter("foo.scala")
+    assert(firstFilter.accept(file))
+    val andNotFilter = firstFilter - new SimpleFilter(_.endsWith("scala"))
+    assert(!andNotFilter.accept(file))
+  }
+  it should "negate filters" in {
+    val file = new File("foo.scala")
+    val firstFilter = new ExactFilter("foo.scala")
+    assert(firstFilter.accept(file))
+    val notFilter = -firstFilter
+    assert(!notFilter.accept(file))
+    assert(notFilter.toString == s"!ExactFilter(foo.scala)")
+  }
+}

--- a/io/src/test/scala/sbt/io/GlobFilterSpec.scala
+++ b/io/src/test/scala/sbt/io/GlobFilterSpec.scala
@@ -1,0 +1,35 @@
+package sbt.io
+import java.io.File
+
+import org.scalatest.{ FlatSpec, Matchers }
+
+class GlobFilterSpec extends FlatSpec with Matchers {
+  "GlobFilter" should "work with *" in {
+    assert(GlobFilter("*") == AllPassFilter)
+  }
+  it should "work with no *" in {
+    assert(GlobFilter("foo.txt") == new ExactFilter("foo.txt"))
+    assert(GlobFilter("foo.txt").accept("foo.txt"))
+  }
+  it should "work with simple extensions" in {
+    assert(GlobFilter("*.txt") == new ExtensionFilter("txt"))
+    assert(GlobFilter("*.txt").accept("foo.txt"))
+  }
+  it should "combine extensions" in {
+    assert((GlobFilter("*.scala") && GlobFilter("*.java")) == new ExtensionFilter())
+    assert((GlobFilter("*.scala") & GlobFilter("*.java")) == new ExtensionFilter())
+    assert((GlobFilter("*.scala") || GlobFilter("*.java")) == new ExtensionFilter("scala", "java"))
+    assert((GlobFilter("*.scala") | GlobFilter("*.java")) == new ExtensionFilter("scala", "java"))
+    val scalaFilter = new ExtensionFilter("scala")
+    assert((GlobFilter("*.scala") || GlobFilter("*.java") -- GlobFilter("*.java")) == scalaFilter)
+    assert((GlobFilter("*.scala") || GlobFilter("*.java") - GlobFilter("*.java")) == scalaFilter)
+    assert((GlobFilter("*.scala") -- ExistsFileFilter).accept(new File("foo.scala")))
+    assert(!(GlobFilter("*.scala") && ExistsFileFilter).accept(new File("foo.scala")))
+    assert((GlobFilter("*.scala") || DirectoryFilter).accept(new File(".")))
+  }
+  it should "work with patterns" in {
+    val filter = GlobFilter("foo*.txt")
+    assert(filter.accept(new File("foobar.txt")))
+    assert(!filter.accept(new File("bar.txt")))
+  }
+}

--- a/io/src/test/scala/sbt/io/NameFilterSpec.scala
+++ b/io/src/test/scala/sbt/io/NameFilterSpec.scala
@@ -1,0 +1,56 @@
+package sbt.io
+
+import java.util.regex.Pattern
+
+import org.scalatest.{ FlatSpec, Matchers }
+
+import scala.annotation.tailrec
+
+class NameFilterSpec extends FlatSpec with Matchers {
+  "NameFilter" should "have readable toString() method" in {
+    AllPassFilter.toString shouldBe "AllPassFilter"
+    DirectoryFilter.toString shouldBe "DirectoryFilter"
+    ExistsFileFilter.toString shouldBe "ExistsFileFilter"
+    HiddenFileFilter.toString shouldBe "HiddenFileFilter"
+    NothingFilter.toString shouldBe "NothingFilter"
+    new ExactFilter("foo.txt").toString shouldBe s"ExactFilter(foo.txt)"
+    new PatternFilter(Pattern.compile(".*\\.scala")).toString shouldBe s"PatternFilter(.*\\.scala)"
+  }
+  it should "correctly override equals/hashCode" in {
+    val (foo, bar) = ("foo.txt", "bar.txt")
+    assert(new ExactFilter(foo) == new ExactFilter(foo))
+    assert(new ExactFilter(foo).hashCode == new ExactFilter(foo).hashCode)
+    assert(new ExactFilter(foo) != new ExactFilter(bar))
+    assert(new ExactFilter(foo).hashCode != new ExactFilter(bar).hashCode)
+
+    val (java, scala) = (Pattern.compile(".*\\.java"), Pattern.compile(".*\\.scala"))
+    assert(new PatternFilter(java) == new PatternFilter(java))
+    assert(new PatternFilter(java).hashCode == new PatternFilter(java).hashCode)
+    assert(new PatternFilter(java) != new PatternFilter(scala))
+    assert(new PatternFilter(java).hashCode != new PatternFilter(scala).hashCode)
+  }
+  it should "correctly identify unequal filters" in {
+    val filters = Seq(
+      AllPassFilter,
+      DirectoryFilter,
+      ExistsFileFilter,
+      HiddenFileFilter,
+      NothingFilter,
+      new ExactFilter("foo.txt"),
+      new PatternFilter(Pattern.compile(".*\\.scala"))
+    )
+    @tailrec
+    def check(head: FileFilter, tail: Seq[FileFilter]): Unit = {
+      tail match {
+        case t if t.nonEmpty =>
+          t.foreach { filter =>
+            assert(head != filter && filter != head)
+            assert(head.hashCode != filter.hashCode())
+          }
+          check(t.head, t.tail)
+        case _ => ()
+      }
+    }
+    check(filters.head, filters.tail)
+  }
+}


### PR DESCRIPTION
I'm working on adding proper scoping to WatchSources and this may
require de-duplication of redundant watch sources. To facilitate this,
I'm improving the toString/equals/hashCode methods of a number of
filters so that reporting is better and so that we can discard duplicate
sources (which will have to be compared using their include and exclude
filters).