### PR TITLE
Bump 2.13 to 2.13.0-M5, use scalatest 3.0.6-SNAP5 unconditionally

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ val io = (project in file("io"))
     commonSettings,
     name := "IO",
     libraryDependencies ++= {
-      Vector(scalaCompiler.value % Test, scalaCheck % Test, scalatest.value % Test)
+      Vector(scalaCompiler.value % Test, scalaCheck % Test, scalatest % Test)
     } ++ Vector(appleFileEvents),
     libraryDependencies ++= Seq(jna, jnaPlatform),
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,17 +5,12 @@ object Dependencies {
   val scala210 = "2.10.7"
   val scala211 = "2.11.12"
   val scala212 = "2.12.6"
-  val scala213 = "2.13.0-M4"
+  val scala213 = "2.13.0-M5"
 
   val scalaCompiler = Def.setting { "org.scala-lang" % "scala-compiler" % scalaVersion.value }
 
   val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.14.0"
-  val scalatest = Def.setting {
-    if (scalaVersion.value == "2.13.0-M4")
-      "org.scalatest" %% "scalatest" % "3.0.6-SNAP1"
-    else
-      "org.scalatest" %% "scalatest" % "3.0.5-M1"
-  }
+  val scalatest = "org.scalatest" %% "scalatest" % "3.0.6-SNAP5"
   val jna = "net.java.dev.jna" % "jna" % "4.5.0"
   val jnaPlatform = "net.java.dev.jna" % "jna-platform" % "4.5.0"
   val appleFileEvents = "com.swoval" % "apple-file-events" % "1.3.2"


### PR DESCRIPTION
Fix for the sbt nightly (1.2.x branch)