### PR TITLE
Remove broken JNA code for FreeBSD

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,6 +93,12 @@ val io = (project in file("io"))
       exclude[MissingClassProblem]("sbt.internal.io.JavaMilli$"),
       exclude[MissingClassProblem]("sbt.internal.io.JavaMilli"),
 
+      // These are private classes
+      exclude[MissingClassProblem]("sbt.internal.io.FreeBSD64"),
+      exclude[MissingClassProblem]("sbt.internal.io.FreeBSD64FileStat"),
+      exclude[MissingClassProblem]("sbt.internal.io.FreeBSD64Milli"),
+      exclude[MissingClassProblem]("sbt.internal.io.FreeBSD64Milli$"),
+
       // protected[this]
       exclude[DirectMissingMethodProblem]("sbt.io.CopyOptions.copy*"),
 

--- a/io/src/main/scala/sbt/internal/io/Milli.scala
+++ b/io/src/main/scala/sbt/internal/io/Milli.scala
@@ -224,20 +224,6 @@ private object Linux32Milli extends PosixMilliIntUtim[Linux32] {
   }
 }
 
-private class FreeBSD64FileStat extends StatLong(120, 40, 48)
-private trait FreeBSD64 extends Library with Utimensat[Long] {
-  def stat(filePath: String, buf: FreeBSD64FileStat): Int
-}
-private object FreeBSD64Milli extends PosixMilliLongUtim[FreeBSD64] {
-  protected final val AT_FDCWD: Int = -100
-  protected final val UTIME_OMIT: Long = -2
-  protected def getModifiedTimeNative(filePath: String) = {
-    val stat = new FreeBSD64FileStat
-    checkedIO(filePath) { libc.stat(filePath, stat) }
-    stat.getModifiedTimeNative
-  }
-}
-
 private trait Mac extends Library with Posix[Long] {
   def getattrlist(path: String,
                   attrlist: Attrlist,
@@ -354,7 +340,6 @@ object Milli {
     else
       getOSType match {
         case LINUX                => if (is64Bit) Linux64Milli else Linux32Milli
-        case FREEBSD if (is64Bit) => FreeBSD64Milli
         case MAC                  => MacMilli
         case WINDOWS              => WinMilli
         case _                    => JavaMilli

--- a/io/src/main/scala/sbt/internal/io/Milli.scala
+++ b/io/src/main/scala/sbt/internal/io/Milli.scala
@@ -339,10 +339,10 @@ object Milli {
       JavaMilli
     else
       getOSType match {
-        case LINUX                => if (is64Bit) Linux64Milli else Linux32Milli
-        case MAC                  => MacMilli
-        case WINDOWS              => WinMilli
-        case _                    => JavaMilli
+        case LINUX   => if (is64Bit) Linux64Milli else Linux32Milli
+        case MAC     => MacMilli
+        case WINDOWS => WinMilli
+        case _       => JavaMilli
       }
 
   def getModifiedTime(file: File): Long =


### PR DESCRIPTION
FreeBSD 12 changed the `struct stat` ABI, with the consequence that the sbt io code badly breaks and make the JVM to crash in very unexpected ways.

I have patches for the openjdk8 port, that will be committed soon, that adds millisecond resolution to the get/setLastModifiedTime functions, so this custom native code is not needed anymore.

This patch can be merged also in the 1.2.x branch.