### PR TITLE
avoid exposing private type in API

### DIFF
--- a/io/src/main/scala/sbt/io/Using.scala
+++ b/io/src/main/scala/sbt/io/Using.scala
@@ -69,9 +69,9 @@ object Using {
       def close(s: T) = closeF(s)
     }
 
-  def file[T <: AutoCloseable](openF: File => T): OpenFile[T] = file(openF, closeCloseable)
+  def file[T <: AutoCloseable](openF: File => T): Using[File, T] = file(openF, closeCloseable)
 
-  def file[T](openF: File => T, closeF: T => Unit): OpenFile[T] =
+  def file[T](openF: File => T, closeF: T => Unit): Using[File, T] =
     new OpenFile[T] {
       def openImpl(file: File) = openF(file)
       def close(t: T) = closeF(t)


### PR DESCRIPTION
a bunch of methods in `Using` expose `OpenFile[T]` as a type. It took me a while to figure out that it was a subtype of `Using[File, T]` since `OpenFile` isn't exposed. I reckon changing the exposed type could improve UX. This is so since the first commit, so I don't know if there's a particular reason.