### PR TITLE
Add dsl for specifying sources

### DIFF
--- a/io/src/main/scala/sbt/io/syntax.scala
+++ b/io/src/main/scala/sbt/io/syntax.scala
@@ -1,4 +1,5 @@
 package sbt.io
+import sbt.internal.io.Source
 
 private[sbt] trait Alternative[A, B] {
   def |(g: A => Option[B]): A => Option[B]
@@ -18,6 +19,8 @@ object syntax extends IOSyntax0 {
   type File = java.io.File
   type URI = java.net.URI
   type URL = java.net.URL
+  val * = PathFinder.*
+  val ** = PathFinder.**
 
   def uri(s: String): URI = new URI(s)
   def file(s: String): File = new File(s)
@@ -25,4 +28,5 @@ object syntax extends IOSyntax0 {
 
   implicit def fileToRichFile(file: File): RichFile = new RichFile(file)
   implicit def filesToFinder(cc: Traversable[File]): PathFinder = PathFinder.strict(cc)
+  implicit def sourceToRichSource(source: Source): RichSource = new RichSource(source)
 }

--- a/io/src/test/scala/sbt/io/GlobFilterSpec.scala
+++ b/io/src/test/scala/sbt/io/GlobFilterSpec.scala
@@ -1,7 +1,11 @@
 package sbt.io
 import java.io.File
+import java.nio.file.Files
 
 import org.scalatest.{ FlatSpec, Matchers }
+import sbt.internal.io.Source
+
+import scala.util.Properties
 
 class GlobFilterSpec extends FlatSpec with Matchers {
   "GlobFilter" should "work with *" in {
@@ -31,5 +35,106 @@ class GlobFilterSpec extends FlatSpec with Matchers {
     val filter = GlobFilter("foo*.txt")
     assert(filter.accept(new File("foobar.txt")))
     assert(!filter.accept(new File("bar.txt")))
+  }
+}
+
+object GlobFilterSyntaxSpec {
+  implicit class PathFinderOps(val source: Source) {
+    def pathSet: Set[java.nio.file.Path] = {
+      val baseFinder = PathFinder(source.base)
+      val filter = source.includeFilter -- source.excludeFilter
+      val finder = if (source.recursive) baseFinder ** filter else baseFinder * filter
+      finder.get().map(_.toPath).toSet
+    }
+  }
+}
+class GlobFilterSyntaxSpec extends FlatSpec with Matchers {
+  import syntax._
+  import GlobFilterSyntaxSpec._
+
+  "**" should "collect all files" in IO.withTemporaryDirectory { dir =>
+    val f = Files.createFile(dir.toPath.resolve("file"))
+    val subdir = Files.createDirectories(dir.toPath.resolve("subdir"))
+    val subdirFile = Files.createFile(subdir.resolve("file"))
+
+    val globbedPaths = (dir / **).pathSet
+    val expected = Set(dir.toPath, f, subdir, subdirFile)
+    assert(globbedPaths == expected)
+  }
+  it should "filter by extension" in IO.withTemporaryDirectory { dir =>
+    val baseScala = Files.createFile(dir.toPath.resolve("Base.scala"))
+    val subdir = Files.createDirectories(dir.toPath.resolve("subdir"))
+    val subScala = Files.createFile(subdir.resolve("Sub.scala"))
+    val subJava = Files.createFile(subdir.resolve("Sub.java"))
+
+    val globbedScalaPaths = (dir / ** / *.scala).pathSet
+    val expectedScalaPaths = Set(baseScala, subScala)
+    assert(globbedScalaPaths == expectedScalaPaths)
+
+    val globbedJavaPaths = (dir / ** / *.java).pathSet
+    val expectedJavaPaths = Set(subJava)
+    assert(globbedJavaPaths == expectedJavaPaths)
+
+    val globbedSourcePaths = (dir / ** / (*.scala | *.java)).pathSet
+    val expectedSourcePaths = expectedJavaPaths ++ expectedScalaPaths
+    assert(globbedSourcePaths == expectedSourcePaths)
+  }
+  "*" should "collect base files" in IO.withTemporaryDirectory { dir =>
+    val baseScala = Files.createFile(dir.toPath.resolve("Base.scala"))
+    val baseJava = Files.createFile(dir.toPath.resolve("Base.java"))
+    val subdir = Files.createDirectories(dir.toPath.resolve("subdir"))
+    val subScala = Files.createFile(subdir.resolve("Sub.scala"))
+    val subJava = Files.createFile(subdir.resolve("Sub.java"))
+
+    val globbedScalaPaths = (dir / *.scala).pathSet
+    val expectedScalaPaths = Set(baseScala)
+    assert(globbedScalaPaths == expectedScalaPaths)
+
+    val globbedJavaPaths = (dir / *.java).pathSet
+    val expectedJavaPaths = Set(baseJava)
+    assert(globbedJavaPaths == expectedJavaPaths)
+
+    val allPaths = (dir / **).pathSet
+    val expectedAllPaths = Set(dir.toPath, subdir, baseScala, baseJava, subScala, subJava)
+    assert(allPaths == expectedAllPaths)
+  }
+  it should "work with string components" in IO.withTemporaryDirectory { dir =>
+    val subdir = Files.createDirectories(dir.toPath.resolve("subdir"))
+    val subScala = Files.createFile(subdir.resolve("Sub.scala"))
+    val subJava = Files.createFile(subdir.resolve("Sub.java"))
+
+    val globbedScalaPaths = (dir / "subdir" / *.scala).pathSet
+    val expectedScalaPaths = Set(subScala)
+    assert(globbedScalaPaths == expectedScalaPaths)
+
+    val globbedJavaPaths = (dir / "subdir" / *.java).pathSet
+    val expectedJavaPaths = Set(subJava)
+    assert(globbedJavaPaths == expectedJavaPaths)
+
+    val allPaths = (dir / "subdir" / *).pathSet
+    val expectedAllPaths = Set(subScala, subJava)
+    assert(allPaths == expectedAllPaths)
+  }
+  "strings" should "have same semantics as objects" in IO.withTemporaryDirectory { dir =>
+    // windows doesn't like paths with "*" in them.
+    if (!Properties.isWin) {
+      val baseScala = Files.createFile(dir.toPath.resolve("Base.scala"))
+      Files.createFile(dir.toPath.resolve("Base.java"))
+      val subdir = Files.createDirectories(dir.toPath.resolve("subdir"))
+      val subScala = Files.createFile(subdir.resolve("Sub.scala"))
+      Files.createFile(subdir.resolve("Sub.java"))
+
+      val globbedStringScalaPaths = (dir / "*.scala").toSource.pathSet
+      val expectedScalaPaths = (dir / *.scala).pathSet
+      assert(globbedStringScalaPaths == expectedScalaPaths)
+
+      val globbedJavaPaths = (dir / "*.java").toSource.pathSet
+      val expectedJavaPaths = (dir / *.java).pathSet
+      assert(globbedJavaPaths == expectedJavaPaths)
+
+      val allStringScalaPaths = (dir / "**" / "*.scala").toSource.pathSet
+      val expectedAllPaths = Set(baseScala, subScala)
+      assert(allStringScalaPaths == expectedAllPaths)
+    }
   }
 }


### PR DESCRIPTION
It is somewhat clunky in sbt to declare a new source. One must write
something like:
watchSources += Source(sourceDirectory.value, "*.proto", NothingFilter, true)

This gets tedious and is somewhat hard to read. In this commit, I add a
simple dsl that allows us to build up soures:
watchSources += sourceDirectory.value / ** / *.proto
I think this is more readable and makes the intent more clear.