### PR TITLE
Bump swoval

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,5 +13,5 @@ object Dependencies {
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.6-SNAP3"
   val jna = "net.java.dev.jna" % "jna" % "4.5.0"
   val jnaPlatform = "net.java.dev.jna" % "jna-platform" % "4.5.0"
-  val swovalFiles = "com.swoval" % "file-tree-views" % "2.0.6"
+  val swovalFiles = "com.swoval" % "file-tree-views" % "2.0.7"
 }


### PR DESCRIPTION
I found an off by one error that would erroneously evict a subdirectory
from monitoring if both the subdirectory and its parent were registered
with depth=0.  This is fairly rare in normal sbt builds since usually
only the base directory is registered with depth=0, but I discovered it
in a scripted test and it surely would have caused an issue for some
users.