### PR TITLE
Don't call sys.error in IO.createDirectory

### DIFF
--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -324,9 +324,9 @@ object IO {
         ()
       } catch {
         case _: FileAlreadyExistsException =>
-          sys.error(failBase + ": file exists and is not a directory.")
+          throw new FileAlreadyExistsException(failBase + ": file exists and is not a directory.")
         case _: IOException if count < 5 => create(count + 1)
-        case _: IOException              => sys.error(failBase)
+        case e: IOException              => throw new IOException(failBase + ": " + e, e)
       }
     if (!Files.isDirectory(path)) create()
   }

--- a/io/src/main/scala/sbt/io/Using.scala
+++ b/io/src/main/scala/sbt/io/Using.scala
@@ -4,14 +4,12 @@
 package sbt
 package io
 
-import java.io.{ File, FileInputStream, FileOutputStream, InputStream, OutputStream }
-import java.io.{ BufferedInputStream, BufferedOutputStream, InputStreamReader, OutputStreamWriter }
-import java.io.{ BufferedReader, BufferedWriter }
+import java.io._
 import java.util.zip.GZIPInputStream
 import java.net.URL
 import java.nio.charset.Charset
 import java.util.jar.{ JarFile, JarInputStream, JarOutputStream }
-import java.util.zip.{ GZIPOutputStream, ZipEntry, ZipFile, ZipInputStream, ZipOutputStream }
+import java.util.zip._
 
 import sbt.internal.io.ErrorHandling.translate
 
@@ -38,8 +36,10 @@ private[sbt] trait OpenFile[T] extends Using[File, T] {
   protected def openImpl(file: File): T
   protected final def open(file: File): T = {
     val parent = file.getParentFile
-    if (parent != null)
-      IO.createDirectory(parent)
+    if (parent != null) {
+      try IO.createDirectory(parent)
+      catch { case _: IOException => }
+    }
     openImpl(file)
   }
 }


### PR DESCRIPTION
There is no reason to ever assume that IO.createDirectory will succeed
so sys.error is inappropriate. This was causing me a lot of pain in
windows where this function will sporadically fail if there is io
contention even if the directory exists.