### PR TITLE
Bump swoval version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,5 +13,5 @@ object Dependencies {
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.6-SNAP3"
   val jna = "net.java.dev.jna" % "jna" % "4.5.0"
   val jnaPlatform = "net.java.dev.jna" % "jna-platform" % "4.5.0"
-  val swovalFiles = "com.swoval" % "file-tree-views" % "2.0.7"
+  val swovalFiles = "com.swoval" % "file-tree-views" % "2.1.0"
 }


### PR DESCRIPTION
I discovered a nasty performance bug that impacted windows and linux in
swoval. Whenever the background watch process for the global file
repository detected that a directory was modified, it would rescan the
entire directory to determine what had changed. This could cause a huge
amount of io to happen if there were a lot of files in the modified
directory. It also was generally unnecessary because the directory
should have been updated via incremental file updates. This change does
make it slightly more likely that the cache will get out of sync with
the file system, but the cache is easily flushed and users can disable
it if they have any issues anyway.