### PR TITLE
Convert glob base path to absolute path

### DIFF
--- a/io/src/main/scala/sbt/io/Glob.scala
+++ b/io/src/main/scala/sbt/io/Glob.scala
@@ -54,13 +54,17 @@ object Glob {
     override def hashCode: Int = f.hashCode
     override def toString: String = s"ConvertedFileFilter($f)"
   }
+  private implicit class PathOps(val p: NioPath) extends AnyVal {
+    def abs: NioPath = if (p.isAbsolute) p else p.toAbsolutePath
+  }
   def apply(base: File, filter: FileFilter, depth: Int): Glob =
-    new GlobImpl(base.toPath, filter, depth)
+    new GlobImpl(base.toPath.abs, filter, depth)
   def apply(base: File, filter: TypedPath => Boolean, depth: Int): Glob =
-    new GlobImpl(base.toPath, filter, depth)
-  def apply(base: NioPath, filter: FileFilter, depth: Int): Glob = new GlobImpl(base, filter, depth)
+    new GlobImpl(base.toPath.abs, filter, depth)
+  def apply(base: NioPath, filter: FileFilter, depth: Int): Glob =
+    new GlobImpl(base.abs, filter, depth)
   def apply(base: NioPath, filter: TypedPath => Boolean, depth: Int): Glob =
-    new GlobImpl(base, filter, depth)
+    new GlobImpl(base.abs, filter, depth)
   private class GlobImpl(val base: NioPath, val filter: TypedPath => Boolean, val depth: Int)
       extends Glob {
     override def toString: String =


### PR DESCRIPTION
If one does not convert the glob path to an absolute path, then the
filter that checks that the path starts with the base does not work. In
general, we want to use absolute paths as much as possible even though
there may be a memory overhead to doing so.

This was needed because the project/extra scripted test started failing
once I updated swoval to correctly handle relative paths. There was a
line like `(file("lib_managed") ** "*.jar").get` that was returning no
results even though there were jars in that directory. This was because
of the aforementioned filtering issue relative to the base directory.