### PR TITLE
Unseal Glob

### DIFF
--- a/io/src/main/scala/sbt/io/Glob.scala
+++ b/io/src/main/scala/sbt/io/Glob.scala
@@ -19,7 +19,7 @@ import sbt.io.FileTreeDataView.Entry
 /**
  * Represents a filtered subtree of the file system.
  */
-sealed trait Glob {
+trait Glob {
 
   /**
    * The root of the file system subtree.


### PR DESCRIPTION
Glob is a very simple pure interface. There is no reason to seal it and
we might want to allow people to do things like override the toString of
the default Glob implementation.