### PR TITLE
Add doc to ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
   include:
    - scala: 2.12.8
      env:
-         CMD="mimaReportBinaryIssues scalafmtCheck test whitesourceCheckPolicies"
+         CMD="mimaReportBinaryIssues scalafmtCheck test whitesourceCheckPolicies doc"
          TRAVIS_SCALA_VERSION=2.12.8
      os: linux
      dist: trusty


### PR DESCRIPTION
The current master was not actually publishable because doc failed due
to -Xfatal-warnings.