### PR TITLE
Don't return empty files in parseClasspath

### DIFF
--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -591,6 +591,7 @@ object IO {
 
   /**
    * Creates a zip file.
+   *
    * @param sources The files to include in the zip file paired with the entry name in the zip.
    *                Only the pairs explicitly listed are included.
    * @param outputZip The file to write the zip to.
@@ -1122,7 +1123,8 @@ object IO {
   def assertAbsolute(uri: URI) = assert(uri.isAbsolute, "Not absolute: " + uri)
 
   /** Parses a classpath String into File entries according to the current platform's path separator.*/
-  def parseClasspath(s: String): Seq[File] = IO.pathSplit(s).map(new File(_)).toSeq
+  def parseClasspath(s: String): Seq[File] =
+    if (s.isEmpty) Nil else IO.pathSplit(s).map(new File(_)).toSeq
 
   /**
    * Constructs an `ObjectInputStream` on `wrapped` that uses `loader` to load classes.

--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -298,7 +298,7 @@ object IO {
    * Creates a file at the given location if it doesn't exist.
    * If the file already exists and `setModified` is true, this method sets the last modified time to the current time.
    */
-  def touch(file: File, setModified: Boolean = true): Unit = {
+  def touch(file: File, setModified: Boolean = true): Unit = Retry {
     val absFile = file.getAbsoluteFile
     createDirectory(absFile.getParentFile)
     val created = translate("Could not create file " + absFile) { absFile.createNewFile() }


### PR DESCRIPTION
Zinc will pass in an empty string into this method if a system property
isn't set. It doesn't make sense to handle the empty string as a
relative file. I noticed this because sbt now prints a warning if one
tries to list a relative glob (which is generated by the pathfinder dsl
in zinc).