### PR TITLE
Fix glob conversion from certain file filters

### DIFF
--- a/io/src/main/scala/sbt/internal/nio/Globs.scala
+++ b/io/src/main/scala/sbt/internal/nio/Globs.scala
@@ -66,9 +66,9 @@ private[sbt] object Globs {
             case _                                           => None
           }
         }
-      case AllPassFilter | HiddenFileFilter => Some(AnyPath)
-      case NothingFilter                    => Some(NoPath)
-      case _                                => None
+      case AllPassFilter | NotHiddenFileFilter => Some(AnyPath)
+      case NothingFilter | HiddenFileFilter    => Some(NoPath)
+      case _                                   => None
     }
   private[sbt] def nameFilterToRelativeGlob(nameFilter: NameFilter): Option[Matcher] =
     nameFilter match {

--- a/io/src/main/scala/sbt/io/NameFilter.scala
+++ b/io/src/main/scala/sbt/io/NameFilter.scala
@@ -200,6 +200,11 @@ case object HiddenFileFilter extends FileFilter {
   def accept(file: File): Boolean =
     try Files.isHidden(file.toPath) && file.getName != "."
     catch { case _: IOException => false }
+  override def unary_- : FileFilter = NotHiddenFileFilter
+}
+private[sbt] case object NotHiddenFileFilter extends FileFilter {
+  def accept(file: File): Boolean = !HiddenFileFilter.accept(file)
+  override def unary_- : FileFilter = HiddenFileFilter
 }
 
 /** A [[FileFilter]] that selects files that exist according to `java.io.File.exists`. */

--- a/io/src/test/scala/sbt/internal/nio/GlobsSpec.scala
+++ b/io/src/test/scala/sbt/internal/nio/GlobsSpec.scala
@@ -119,4 +119,15 @@ class GlobsSpec extends FlatSpec {
     assert(!Globs(dirPath, recursive = true, -DirectoryFilter).matches(subdir))
     assert(Globs(dirPath, recursive = true, -DirectoryFilter).matches(subFile))
   }
+  it should "apply and filter with not hidden file filter" in {
+    val filter = new ExtensionFilter("java", "scala") && -HiddenFileFilter
+    val glob = Globs(basePath, recursive = true, filter)
+    assert(glob.matches(basePath.resolve("foo").resolve("bar.scala")))
+  }
+  it should "apply and filter with not filter" in {
+    val filter = new ExtensionFilter("java", "scala") && -new PrefixFilter("bar")
+    val glob = Globs(basePath, recursive = true, filter)
+    assert(!glob.matches(basePath.resolve("foo").resolve("bar.scala")))
+    assert(glob.matches(basePath.resolve("foo").resolve("baz.java")))
+  }
 }


### PR DESCRIPTION
Issue https://github.com/sbt/sbt/issues/4687 reports that sbt 1.3.0-RC1
does not work correctly with the sbt header plugin. This is because the
plugin uses the Defaults.collectFiles method that was changed to use
globs. There was an issue with the base path + file filter conversion
where if the filter was, say, AllPassFilter && !HiddenFileFilter, this
actually got translated to $baseDiretory/**/<null> (where <null>
indicates the NoPath filter). The primary cause of this issue was an
incorrect conversion from HiddenFileFilter to AnyPath. Hidden files
are automatically excluded by globs so the HiddenFileFilter is actually
equivalent to the NoPath filter. I also added the NotHiddenFileFilter
object to be the inverse of the HiddenFileFilter because
-HiddenFileFilter comes up in a lot of places so I think it makes sense
to handle it directly.