### PR TITLE
Fix extension filter

### DIFF
--- a/io/src/main/scala/sbt/io/NameFilter.scala
+++ b/io/src/main/scala/sbt/io/NameFilter.scala
@@ -333,10 +333,11 @@ object GlobFilter {
     else {
       val parts = expression.split("\\*", -1)
       parts match {
-        case Array("", ext) if ext.startsWith(".") => new ExtensionFilter(ext.drop(1))
-        case Array(prefix, "")                     => new PrefixFilter(prefix)
-        case Array("", suffix)                     => new SuffixFilter(suffix)
-        case _                                     => new PatternFilter(parts, Pattern.compile(parts.map(quote).mkString(".*")))
+        case Array("", ext) if ext.startsWith(".") && !ext.drop(1).contains(".") =>
+          new ExtensionFilter(ext.drop(1))
+        case Array(prefix, "") => new PrefixFilter(prefix)
+        case Array("", suffix) => new SuffixFilter(suffix)
+        case _                 => new PatternFilter(parts, Pattern.compile(parts.map(quote).mkString(".*")))
       }
     }
   }

--- a/io/src/test/scala/sbt/io/PathFinderSpec.scala
+++ b/io/src/test/scala/sbt/io/PathFinderSpec.scala
@@ -60,6 +60,11 @@ trait PathFinderSpec extends FlatSpec with Matchers {
     PathFinder(dir).descendantsExcept("*", "*sub*").get.toSet shouldBe Set(dir, file)
     PathFinder(dir).descendantsExcept("*", NothingFilter).get.toSet shouldBe Set(dir, file, subdir)
   }
+  it should "work for complex extension filters" in IO.withTemporaryDirectory { dir =>
+    val subdir = Files.createDirectories(dir.toPath.resolve("subdir"))
+    val file = Files.createFile(subdir.resolve("foo.template.scala")).toFile
+    assert(PathFinder(dir).globRecursive("*.template.scala").get() == Seq(file))
+  }
   it should "follow links" in IO.withTemporaryDirectory { dir =>
     IO.withTemporaryDirectory { otherDir =>
       val foo = Files.createTempFile(otherDir.toPath, "foo", "")


### PR DESCRIPTION
I noticed that sbt 1.3.0 had problems with the twirl template compiler
and I tracked it down to the template compiler calling effectively
(sourceDirectories `**` "*.template.scala").get.

This created an instance ofExtensionFilter with the extension "template.scala". The problem was
that ExtensionFilter had an implicit assumption that the extension
didn't have any additional dots in it. This allowed it to consolidate
"*.java" || "*.scala" into ExtensionFilter("java", "scala"). This
optimization does not really work for more complicated extensions so I
added a check that the extension doesn't have any dots in it.