### PR TITLE
Add missing pattern case

### DIFF
--- a/io/src/main/scala/sbt/internal/nio/Globs.scala
+++ b/io/src/main/scala/sbt/internal/nio/Globs.scala
@@ -113,5 +113,6 @@ private[sbt] object Globs {
       case pf: PrefixFilter  => Some(Matcher(s"${pf.prefix}*"))
       case sf: SimpleFilter  => Some(Matcher(sf.acceptFunction))
       case sf: SuffixFilter  => Some(Matcher(s"*${sf.suffix}"))
+      case _                 => None
     }
 }

--- a/io/src/test/scala/sbt/internal/nio/GlobsSpec.scala
+++ b/io/src/test/scala/sbt/internal/nio/GlobsSpec.scala
@@ -119,6 +119,15 @@ class GlobsSpec extends FlatSpec {
     assert(!Globs(dirPath, recursive = true, -DirectoryFilter).matches(subdir))
     assert(Globs(dirPath, recursive = true, -DirectoryFilter).matches(subFile))
   }
+  it should "apply anonymous filters" in IO.withTemporaryDirectory { dir =>
+    val dirPath = dir.toPath
+    val file = Files.createFile(dirPath.resolve("file.template"))
+    val regex = ".*\\.template".r
+    val filter = new NameFilter {
+      override def accept(name: String): Boolean = regex.pattern.matcher(name).matches()
+    }
+    assert(Globs(dirPath, recursive = false, filter).matches(file))
+  }
   it should "apply and filter with not hidden file filter" in {
     val filter = new ExtensionFilter("java", "scala") && -HiddenFileFilter
     val glob = Globs(basePath, recursive = true, filter)


### PR DESCRIPTION
I think that I erroneously assumed that NameFilter was sealed so I
missed a case in the pattern matcher. This issue was reported by
@dwijnand in https://github.com/sbt/sbt/issues/4757.