### PR TITLE
Fix directory listing for files with special characters

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,6 +11,6 @@ object Dependencies {
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.8-RC2"
   val jna = "net.java.dev.jna" % "jna" % "4.5.0"
   val jnaPlatform = "net.java.dev.jna" % "jna-platform" % "4.5.0"
-  val swovalFiles = "com.swoval" % "file-tree-views" % "2.1.1"
+  val swovalFiles = "com.swoval" % "file-tree-views" % "2.1.2"
   def nightlyVersion: Option[String] = sys.props.get("sbt.build.version")
 }


### PR DESCRIPTION
Listing directories that contained files whose names contained special
characters, like "^M", was broken on windows. This was because the
swoval library was using the utf-8 encoding instead of the native java
encoding which uses two byte words for characters.

The relevant swoval PR is https://github.com/swoval/swoval/pull/130.