### PR TITLE
Exclude hidden files by default in globs

### DIFF
--- a/io/src/main/scala/sbt/nio/file/Glob.scala
+++ b/io/src/main/scala/sbt/nio/file/Glob.scala
@@ -304,11 +304,13 @@ sealed trait RelativeGlob extends Glob {
 }
 case object RecursiveGlob extends SingleComponentMatcher with RelativeGlob {
   override def glob: String = "**"
-  def matches(path: Path): Boolean = true
+  def matches(path: Path): Boolean =
+    !path.iterator.asScala.exists(_.getFileName.toString.startsWith("."))
 }
 case object AnyPath extends SingleComponentMatcher with RelativeGlob {
   override def glob: String = "*"
-  override def matches(path: Path): Boolean = path.getNameCount == 1
+  override def matches(path: Path): Boolean =
+    path.getNameCount == 1 && !path.getFileName.toString.startsWith(".")
 }
 object RelativeGlob {
   val ** = RecursiveGlob

--- a/io/src/test/scala/sbt/nio/GlobSyntaxSpec.scala
+++ b/io/src/test/scala/sbt/nio/GlobSyntaxSpec.scala
@@ -163,4 +163,15 @@ class GlobSyntaxSpec extends FlatSpec {
       Glob(s"./foo/*").fileTreeViewListParameters._3.matches(Paths.get(s"foo/bar").toAbsolutePath)
     )
   }
+  "hidden files" should "be excluded by default" in {
+    assert(!Glob(basePath, "*").matches(basePath.resolve(".foo")))
+    assert(!Glob(basePath, AnyPath).matches(basePath.resolve(".foo")))
+    assert(!Glob(basePath, "!.*").matches(basePath.resolve(".foo")))
+    assert(Glob(basePath, "!.*").matches(basePath.resolve("foo")))
+    assert(Glob(basePath, "?*").matches(basePath.resolve(".foo")))
+  }
+  they should "be allowed with regex" in {
+    assert(Glob(basePath, "regex:\\.?.*").matches(basePath.resolve(".foo")))
+    assert(Glob(basePath, "regex:\\.?.*").matches(basePath.resolve("foo")))
+  }
 }

--- a/io/src/test/scala/sbt/nio/GlobSyntaxSpec.scala
+++ b/io/src/test/scala/sbt/nio/GlobSyntaxSpec.scala
@@ -163,6 +163,23 @@ class GlobSyntaxSpec extends FlatSpec {
       Glob(s"./foo/*").fileTreeViewListParameters._3.matches(Paths.get(s"foo/bar").toAbsolutePath)
     )
   }
+  "regex syntax" should "apply patterns" in {
+    assert(Glob(basePath, ".*.txt".r).matches(basePath.resolve("foo.txt")))
+    assert(!Glob(basePath, ".*.txt".r).matches(basePath.resolve("foo.tx")))
+    assert(!Glob(basePath, "foo/.*.txt".r).matches(basePath.resolve("foo.txt")))
+    assert(Glob(basePath, "foo/.*.txt".r).matches(basePath.resolve("foo").resolve("foo.txt")))
+    assert(Glob(basePath, "foo/.*.txt".r).matches(basePath.resolve("foo").resolve("foo.txt")))
+    assert((Glob(basePath) / ".*.txt".r).matches(basePath.resolve("foo.txt")))
+    assert(!(Glob(basePath) / ".*.txt".r).matches(basePath.resolve("foo.tx")))
+    assert((Glob(basePath) / ** / ".*.txt".r).matches(basePath.resolve("foo.txt")))
+    assert(!(Glob(basePath) / ** / ".*.txt".r).matches(basePath.resolve("foo.tx")))
+    assert((Glob(basePath) / ** / ".*.txt".r).matches(basePath.resolve("bar").resolve("foo.txt")))
+    assert(!(Glob(basePath) / ** / ".*.txt".r).matches(basePath.resolve("bar").resolve("foo.tx")))
+    assert((Glob(basePath) / ** / ".*.txt$".r).matches(basePath.resolve("bar").resolve("foo.txt")))
+    assert(
+      !(Glob(basePath) / ** / ".*.txt$".r).matches(basePath.resolve("bar").resolve("foo.txt4"))
+    )
+  }
   "hidden files" should "be excluded by default" in {
     assert(!Glob(basePath, "*").matches(basePath.resolve(".foo")))
     assert(!Glob(basePath, AnyPath).matches(basePath.resolve(".foo")))
@@ -173,5 +190,7 @@ class GlobSyntaxSpec extends FlatSpec {
   they should "be allowed with regex" in {
     assert(Glob(basePath, "regex:\\.?.*").matches(basePath.resolve(".foo")))
     assert(Glob(basePath, "regex:\\.?.*").matches(basePath.resolve("foo")))
+    assert(Glob(basePath, "\\.?.*".r).matches(basePath.resolve(".foo")))
+    assert(Glob(basePath, "\\.?.*".r).matches(basePath.resolve("foo")))
   }
 }


### PR DESCRIPTION
This came up while I was writing documentation for Glob. The glob `baseDirectory.value / *` should  exclude hidden files by default. This is what normal shell globs do. To work around, if a user really wants hidden files to be returned, they can write `baseDirectory.value / "regex:\\..*`.