### PR TITLE
Fix Coursier cache location for windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,5 +23,5 @@ test_script:
 
 cache:
   - '%USERPROFILE%\.ivy2\cache'
-  - '%USERPROFILE%\Coursier\Cache\v1'
+  - '%LOCALAPPDATA%\Coursier\Cache\v1'
   - '%USERPROFILE%\.sbt'


### PR DESCRIPTION
This time I verified that the coursier directory was actually cached on windows.