### PR TITLE
Glob hidden file regex cleanup

### DIFF
--- a/io/src/main/scala/sbt/internal/nio/Globs.scala
+++ b/io/src/main/scala/sbt/internal/nio/Globs.scala
@@ -66,9 +66,9 @@ private[sbt] object Globs {
             case _                                           => None
           }
         }
-      case AllPassFilter | NotHiddenFileFilter => Some(AnyPath)
-      case NothingFilter | HiddenFileFilter    => Some(NoPath)
-      case _                                   => None
+      case AllPassFilter => Some(AnyPath)
+      case NothingFilter => Some(NoPath)
+      case _             => None
     }
   private[sbt] def nameFilterToRelativeGlob(nameFilter: NameFilter): Option[Matcher] =
     nameFilter match {

--- a/io/src/main/scala/sbt/nio/file/Glob.scala
+++ b/io/src/main/scala/sbt/nio/file/Glob.scala
@@ -709,11 +709,10 @@ object RelativeGlob {
       case m       => NotMatcher(m)
     }
     private[sbt] def apply(glob: String): Matcher = glob match {
-      case "**"                   => RecursiveGlob
-      case "*"                    => AnyPath
-      case g if g.startsWith("!") => NotMatcher(Matcher(g.drop(1)))
-      case g if !Glob.hasMeta(g)  => PathComponent(g)
-      case g                      => new GlobMatcher(g)
+      case "**"                  => RecursiveGlob
+      case "*"                   => AnyPath
+      case g if !Glob.hasMeta(g) => PathComponent(g)
+      case g                     => new GlobMatcher(g)
     }
     private[sbt] def apply(f: String => Boolean): Matcher = FunctionNameFilter(f)
   }
@@ -789,9 +788,7 @@ object RelativeGlob {
       case i  => (glob.substring(0, i), glob.substring(i + 1))
     }
     private[this] val matcher = FileSystems.getDefault.getPathMatcher(s"$prefix:$pattern")
-    private[this] val needsHiddenFilter = prefix == "glob" && pattern.startsWith("*")
-    override def matches(path: Path): Boolean =
-      matcher.matches(path) && !(needsHiddenFilter && path.getFileName.toString.startsWith("."))
+    override def matches(path: Path): Boolean = matcher.matches(path)
     override def equals(o: Any): Boolean = o match {
       case that: GlobMatcher => this.glob == that.glob
       case _                 => false

--- a/io/src/test/scala/sbt/internal/io/SourceModificationWatchSpec.scala
+++ b/io/src/test/scala/sbt/internal/io/SourceModificationWatchSpec.scala
@@ -557,7 +557,7 @@ object EventMonitorSpec {
   }
   implicit class FileOps(val file: File) extends AnyVal {
     def scalaSourceGlobs: Seq[Glob] =
-      Glob(file.toPath.toRealPath(), RecursiveGlob / "*.scala") :: Nil
+      Glob(file.toPath.toRealPath(), RecursiveGlob / "[!.]*.scala") :: Nil
   }
   class CachingWatchLogger extends Logger {
     val lines = new scala.collection.mutable.ArrayBuffer[String]

--- a/io/src/test/scala/sbt/internal/nio/GlobsSpec.scala
+++ b/io/src/test/scala/sbt/internal/nio/GlobsSpec.scala
@@ -147,4 +147,17 @@ class GlobsSpec extends FlatSpec {
     assert(glob.matches(basePath.resolve("foo").resolve("Foo.scala")))
     assert(!glob.matches(basePath.resolve("foo").resolve("Bar.scala")))
   }
+  "hidden files" should "be included by default" in {
+    val glob = Globs(basePath, recursive = true, "*.scala")
+    assert(glob.matches(basePath.resolve("foo").resolve("Foo.scala")))
+    assert(glob.matches(basePath.resolve("foo").resolve("bar").resolve(".Bar.scala")))
+  }
+  they should "be excluded by filter" in {
+    val glob = Globs(basePath, recursive = true, ("*.scala": NameFilter) -- HiddenFileFilter)
+    assert(glob.matches(basePath.resolve("foo").resolve("Foo.scala")))
+    assert(
+      scala.util.Properties.isWin ||
+        !glob.matches(basePath.resolve("foo").resolve("bar").resolve(".Bar.scala"))
+    )
+  }
 }

--- a/io/src/test/scala/sbt/nio/GlobSyntaxSpec.scala
+++ b/io/src/test/scala/sbt/nio/GlobSyntaxSpec.scala
@@ -163,4 +163,33 @@ class GlobSyntaxSpec extends FlatSpec {
       Glob(s"./foo/*").fileTreeViewListParameters._3.matches(Paths.get(s"foo/bar").toAbsolutePath)
     )
   }
+  "dot files" should "not be excluded by default" in {
+    assert(Glob(basePath, "*").matches(basePath.resolve(".foo")))
+    assert(Glob(basePath, AnyPath).matches(basePath.resolve(".foo")))
+    assert(!Glob(basePath, "[!.]*").matches(basePath.resolve(".foo")))
+    assert(Glob(basePath, "[!.]*").matches(basePath.resolve("foo")))
+    assert(Glob(basePath, "?*").matches(basePath.resolve(".foo")))
+  }
+  they should "be excluded with filter" in {
+    val noHiddenFiles = Glob(basePath, "[!.]*")
+    assert(!noHiddenFiles.matches(basePath.resolve(".foo")))
+    assert(noHiddenFiles.matches(basePath.resolve("foo")))
+    assert(!noHiddenFiles.matches(basePath.resolve(".f")))
+    assert(noHiddenFiles.matches(basePath.resolve("f")))
+    val noHiddenScalaFiles = Glob(basePath, "[!.]*.scala")
+    assert(noHiddenScalaFiles.matches(basePath.resolve("Foo.scala")))
+    assert(!noHiddenScalaFiles.matches(basePath.resolve(".Foo.scala")))
+    assert(noHiddenScalaFiles.matches(basePath.resolve("a.scala")))
+  }
+  they should "be excluded with regex filter" in {
+    val noHiddenFiles = Glob(basePath, "regex:^[^.].*")
+    assert(!noHiddenFiles.matches(basePath.resolve(".foo")))
+    assert(noHiddenFiles.matches(basePath.resolve("foo")))
+    assert(!noHiddenFiles.matches(basePath.resolve(".f")))
+    assert(noHiddenFiles.matches(basePath.resolve("f")))
+    val noHiddenScalaFiles = Glob(basePath, "regex:^[^.].*\\.scala$")
+    assert(noHiddenScalaFiles.matches(basePath.resolve("Foo.scala")))
+    assert(!noHiddenScalaFiles.matches(basePath.resolve(".Foo.scala")))
+    assert(noHiddenScalaFiles.matches(basePath.resolve("a.scala")))
+  }
 }

--- a/io/src/test/scala/sbt/nio/GlobSyntaxSpec.scala
+++ b/io/src/test/scala/sbt/nio/GlobSyntaxSpec.scala
@@ -163,6 +163,23 @@ class GlobSyntaxSpec extends FlatSpec {
       Glob(s"./foo/*").fileTreeViewListParameters._3.matches(Paths.get(s"foo/bar").toAbsolutePath)
     )
   }
+  "regex syntax" should "apply patterns" in {
+    assert(Glob(basePath, ".*.txt".r).matches(basePath.resolve("foo.txt")))
+    assert(!Glob(basePath, ".*.txt".r).matches(basePath.resolve("foo.tx")))
+    assert(!Glob(basePath, "foo/.*.txt".r).matches(basePath.resolve("foo.txt")))
+    assert(Glob(basePath, "foo/.*.txt".r).matches(basePath.resolve("foo").resolve("foo.txt")))
+    assert(Glob(basePath, "foo/.*.txt".r).matches(basePath.resolve("foo").resolve("foo.txt")))
+    assert((Glob(basePath) / ".*.txt".r).matches(basePath.resolve("foo.txt")))
+    assert(!(Glob(basePath) / ".*.txt".r).matches(basePath.resolve("foo.tx")))
+    assert((Glob(basePath) / ** / ".*.txt".r).matches(basePath.resolve("foo.txt")))
+    assert(!(Glob(basePath) / ** / ".*.txt".r).matches(basePath.resolve("foo.tx")))
+    assert((Glob(basePath) / ** / ".*.txt".r).matches(basePath.resolve("bar").resolve("foo.txt")))
+    assert(!(Glob(basePath) / ** / ".*.txt".r).matches(basePath.resolve("bar").resolve("foo.tx")))
+    assert((Glob(basePath) / ** / ".*.txt$".r).matches(basePath.resolve("bar").resolve("foo.txt")))
+    assert(
+      !(Glob(basePath) / ** / ".*.txt$".r).matches(basePath.resolve("bar").resolve("foo.txt4"))
+    )
+  }
   "dot files" should "not be excluded by default" in {
     assert(Glob(basePath, "*").matches(basePath.resolve(".foo")))
     assert(Glob(basePath, AnyPath).matches(basePath.resolve(".foo")))
@@ -182,14 +199,18 @@ class GlobSyntaxSpec extends FlatSpec {
     assert(noHiddenScalaFiles.matches(basePath.resolve("a.scala")))
   }
   they should "be excluded with regex filter" in {
-    val noHiddenFiles = Glob(basePath, "regex:^[^.].*")
+    val noHiddenFiles = Glob(basePath, "^[^.].*".r)
     assert(!noHiddenFiles.matches(basePath.resolve(".foo")))
     assert(noHiddenFiles.matches(basePath.resolve("foo")))
     assert(!noHiddenFiles.matches(basePath.resolve(".f")))
     assert(noHiddenFiles.matches(basePath.resolve("f")))
-    val noHiddenScalaFiles = Glob(basePath, "regex:^[^.].*\\.scala$")
+    val noHiddenScalaFiles = Glob(basePath, "^[^.].*[.]scala$".r)
     assert(noHiddenScalaFiles.matches(basePath.resolve("Foo.scala")))
     assert(!noHiddenScalaFiles.matches(basePath.resolve(".Foo.scala")))
     assert(noHiddenScalaFiles.matches(basePath.resolve("a.scala")))
+    val altNoHiddenScalaFiles = Glob(basePath, "^[^.].*\\.scala$".r)
+    assert(altNoHiddenScalaFiles.matches(basePath.resolve("Foo.scala")))
+    assert(!altNoHiddenScalaFiles.matches(basePath.resolve(".Foo.scala")))
+    assert(altNoHiddenScalaFiles.matches(basePath.resolve("a.scala")))
   }
 }


### PR DESCRIPTION
This PR makes Globs accept hidden files by default. We can filter them out in the sbt layer. It also adds a syntax for specifying globs with regex, e.g:
```
val regexGlob = baseDirectory.value.toGlob / ** / "[^.].*\\.scala".r
```