### PR TITLE
Path filter

### DIFF
--- a/io/src/main/scala/sbt/internal/nio/SwovalConverters.scala
+++ b/io/src/main/scala/sbt/internal/nio/SwovalConverters.scala
@@ -10,7 +10,6 @@
 
 package sbt.internal.nio
 
-import java.io.IOException
 import java.nio.file.Path
 
 import com.swoval.files.FileTreeViews
@@ -41,17 +40,15 @@ private[sbt] object SwovalFileTreeView extends FileTreeView.Nio[FileAttributes] 
   private[this] val view = FileTreeViews.getDefault(true)
   override def list(path: Path): Seq[(Path, FileAttributes)] = {
     val result = new VectorBuilder[(Path, FileAttributes)]
-    try {
-      view.list(path, 0, _ => true).forEach { typedPath =>
-        result += typedPath.getPath ->
-          FileAttributes(
-            isDirectory = typedPath.isDirectory,
-            isOther = false,
-            isRegularFile = typedPath.isFile,
-            isSymbolicLink = typedPath.isSymbolicLink
-          )
-      }
-    } catch { case _: IOException => }
+    view.list(path, 0, _ => true).forEach { typedPath =>
+      result += typedPath.getPath ->
+        FileAttributes(
+          isDirectory = typedPath.isDirectory,
+          isOther = false,
+          isRegularFile = typedPath.isFile,
+          isSymbolicLink = typedPath.isSymbolicLink
+        )
+    }
     result.result()
   }
 }

--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -587,7 +587,7 @@ object IO {
           catch { case _: IOException => }
       }
     } catch {
-      case _: NotDirectoryException =>
+      case _: NotDirectoryException | _: NoSuchFileException =>
     }
     try Files.deleteIfExists(file.toPath)
     catch { case _: IOException => }

--- a/io/src/main/scala/sbt/io/syntax.scala
+++ b/io/src/main/scala/sbt/io/syntax.scala
@@ -12,6 +12,8 @@ package sbt.io
 
 import java.io.File
 
+import sbt.nio.file.PathFilter
+
 @deprecated("Alternative is likely to be removed in future versions of sbt", "1.3.0")
 private[sbt] trait Alternative[A, B] {
   def |(g: A => Option[B]): A => Option[B]
@@ -40,4 +42,6 @@ object syntax extends IOSyntax0 {
 
   implicit def fileToRichFile(file: File): RichFile = new RichFile(file)
   implicit def filesToFinder(cc: Traversable[File]): PathFinder = PathFinder.strict(cc)
+  implicit def fileFilterToPathFilter(file: FileFilter): PathFilter =
+    PathFilter.fromFileFilter(file)
 }

--- a/io/src/main/scala/sbt/io/syntax.scala
+++ b/io/src/main/scala/sbt/io/syntax.scala
@@ -12,8 +12,6 @@ package sbt.io
 
 import java.io.File
 
-import sbt.nio.file.PathFilter
-
 @deprecated("Alternative is likely to be removed in future versions of sbt", "1.3.0")
 private[sbt] trait Alternative[A, B] {
   def |(g: A => Option[B]): A => Option[B]
@@ -42,6 +40,4 @@ object syntax extends IOSyntax0 {
 
   implicit def fileToRichFile(file: File): RichFile = new RichFile(file)
   implicit def filesToFinder(cc: Traversable[File]): PathFinder = PathFinder.strict(cc)
-  implicit def fileFilterToPathFilter(file: FileFilter): PathFilter =
-    PathFilter.fromFileFilter(file)
 }

--- a/io/src/main/scala/sbt/nio/file/Glob.scala
+++ b/io/src/main/scala/sbt/nio/file/Glob.scala
@@ -273,7 +273,7 @@ object Glob {
   private object Root {
     implicit val ordering: Ordering[Root] = Ordering.by(_.root)
   }
-  private final case class Root(root: Path) extends Glob {
+  private[file] final case class Root(root: Path) extends Glob {
     require(root.isAbsolute, s"Tried to construct absolute glob from relative path $root")
     override def matches(path: Path): Boolean = root == path
     override def toString: String = root.toString

--- a/io/src/main/scala/sbt/nio/file/Glob.scala
+++ b/io/src/main/scala/sbt/nio/file/Glob.scala
@@ -69,7 +69,7 @@ import scala.util.matching.Regex
  *   allScalaAndJavaSources.matches(Paths.get("/foo/bar/baz/fizz/buzz/Buzz.java")) // true
  * }}}
  */
-sealed trait Glob {
+sealed trait Glob extends PathFilter {
 
   /**
    * Indicates whether a path matches the pattern specified by this [[Glob]].
@@ -78,6 +78,14 @@ sealed trait Glob {
    * @return true it the path matches.
    */
   def matches(path: Path): Boolean
+
+  /**
+   * Returns true if the pathname matches the glob pattern.
+   * @param path the path name
+   * @param attributes the file attributes corresponding to `path`
+   * @return true if the path name matches the glob pattern.
+   */
+  override final def accept(path: Path, attributes: FileAttributes): Boolean = matches(path)
 }
 
 object Glob {

--- a/io/src/main/scala/sbt/nio/file/PathFilter.scala
+++ b/io/src/main/scala/sbt/nio/file/PathFilter.scala
@@ -27,7 +27,17 @@ trait PathFilter {
   def accept(path: Path, attributes: FileAttributes): Boolean
 }
 
-object PathFilter {
+private[sbt] trait LowPriorityPathFilter {
+
+  /**
+   * Converts a glob string to a [[sbt.nio.file.PathFilter]].
+   * @param glob the glob string to convert to a filter, e.g. "**<code>/</code>*.scala"
+   * @return the parsed glob. May throw an exception if the glob string can not be parsed into a
+   *         [[Glob]].
+   */
+  implicit def stringToPathFilter(glob: String): PathFilter = Glob(glob)
+}
+object PathFilter extends LowPriorityPathFilter {
 
   /**
    * Returns a PathFilter that accepts any path for which there exists a [[Glob]] that matches
@@ -38,15 +48,18 @@ object PathFilter {
   def apply(globs: Glob*): PathFilter = if (globs.isEmpty) NoPass else new GlobPathFilter(globs)
 
   /**
-   * Provides extension methods for [[PathFilter]]
-   * @param pathFilter the [[PathFilter]] to extend
+   * Provides extension methods for combining or negating [[PathFilter]] instances or
+   * or other filter types that can be safely converted (see [[sbt.io.DirectoryFilter]]
+   * and [[sbt.io.HiddenFileFilter]]).
    */
   implicit class Ops(val pathFilter: PathFilter) extends AnyVal {
 
     /**
-     * Returns a combined [[PathFilter]] that returns true only if both [[PathFilter]] instances
-     * accept the path.
-     * @param other the other [[PathFilter]]
+     * Combines this filter with a [[sbt.nio.file.PathFilter]] to produce a combined filter
+     * that returns true only if both filters accept the path.
+     * @param other the other [[sbt.nio.file.PathFilter]]
+     * @return the [[sbt.nio.file.PathFilter]] representing both filters combined by the `&&`
+     *         operation
      */
     def &&(other: PathFilter): PathFilter = pathFilter match {
       case NoPass  => NoPass
@@ -60,9 +73,11 @@ object PathFilter {
     }
 
     /**
-     * Returns a combined [[PathFilter]] that returns true only if both [[PathFilter]] instances
-     * accept the path.
-     * @param other the other [[PathFilter]]
+     * Combines this filter with a [[sbt.nio.file.PathFilter]] to produce a combined filter
+     * that returns true either if this or the other [[sbt.nio.file.PathFilter]] accept the path.
+     * @param other the other [[sbt.nio.file.PathFilter]]
+     * @return the [[sbt.nio.file.PathFilter]] representing both filters combined by the `&&`
+     *         operation
      */
     def ||(other: PathFilter): PathFilter = pathFilter match {
       case NoPass  => other
@@ -76,15 +91,16 @@ object PathFilter {
     }
 
     /**
-     * Inverts the [[PathFilter.accept]] method.
-     * @return
+     * Creates a new [[sbt.nio.file.PathFilter]] what accepts a `(Path, FileAttributes)` pair only
+     * if this filter does not accept it.
+     * @return the negated [[sbt.nio.file.PathFilter]] corresponding to this filter
      */
     def unary_! : PathFilter = pathFilter match {
-      case AllPass         => NoPass
-      case NoPass          => AllPass
-      case HiddenFilter    => NotHiddenFilter
-      case NotHiddenFilter => HiddenFilter
-      case pf              => new NotPathFilter(pf)
+      case AllPass     => NoPass
+      case NoPass      => AllPass
+      case IsHidden    => IsNotHidden
+      case IsNotHidden => IsHidden
+      case pf          => new NotPathFilter(pf)
     }
   }
 
@@ -96,12 +112,14 @@ object PathFilter {
    * @param fileFilter the filter to convert
    * @return the converted.
    */
-  implicit def fromFileFilter(fileFilter: FileFilter): PathFilter = fileFilter match {
-    case sbt.io.HiddenFileFilter    => HiddenFilter
-    case sbt.io.NotHiddenFileFilter => NotHiddenFilter
+  def fromFileFilter(fileFilter: FileFilter): PathFilter = fileFilter match {
+    case sbt.io.HiddenFileFilter    => IsHidden
+    case sbt.io.NotHiddenFileFilter => IsNotHidden
     case sbt.io.AllPassFilter       => AllPass
     case sbt.io.NothingFilter       => NoPass
-    case sbt.io.DirectoryFilter     => DirectoryFilter
+    case sbt.io.DirectoryFilter     => IsDirectory
+    case sbt.io.RegularFileFilter   => IsRegularFile
+    case pf: PathFilter             => pf
     case nf: sbt.io.NotFilter       => !fromFileFilter(nf.fileFilter)
     case af: sbt.io.AndFilter       => fromFileFilter(af.left) && fromFileFilter(af.right)
     case of: sbt.io.OrFilter        => fromFileFilter(of.left) || fromFileFilter(of.right)
@@ -141,7 +159,7 @@ object PathFilter {
 /**
  * A [[PathFilter]] that includes only directories.
  */
-case object DirectoryFilter extends PathFilter {
+private[sbt] case object IsDirectory extends PathFilter {
 
   /**
    * Returns true if the `path` is a directory
@@ -155,7 +173,7 @@ case object DirectoryFilter extends PathFilter {
 /**
  * A [[PathFilter]] that includes only regular files.
  */
-case object RegularFileFilter extends PathFilter {
+private[sbt] case object IsRegularFile extends PathFilter {
 
   /**
    * Returns true if the `path` is a regular file
@@ -170,7 +188,7 @@ case object RegularFileFilter extends PathFilter {
  * A [[PathFilter]] that includes only hidden files according to
  * [[https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#isHidden-java.nio.file.Path- Files.isHidden]].
  */
-case object HiddenFilter extends PathFilter {
+private[sbt] case object IsHidden extends PathFilter {
 
   /**
    * Returns true if the `path` is hidden according to
@@ -186,11 +204,11 @@ case object HiddenFilter extends PathFilter {
  * A [[PathFilter]] that includes only files that are not hidden according to
  * [[https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#isHidden-java.nio.file.Path- Files.isHidden]].
  */
-case object NotHiddenFilter extends PathFilter {
+private[sbt] case object IsNotHidden extends PathFilter {
   override def accept(path: Path, attributes: FileAttributes): Boolean = !Files.isHidden(path)
 }
 
-case object AllPass extends PathFilter {
+private[sbt] case object AllPass extends PathFilter {
 
   /**
    * Always returns true.
@@ -201,7 +219,7 @@ case object AllPass extends PathFilter {
   override def accept(path: Path, attributes: FileAttributes): Boolean = true
 }
 
-case object NoPass extends PathFilter {
+private[sbt] case object NoPass extends PathFilter {
 
   /**
    * Always returns false.

--- a/io/src/main/scala/sbt/nio/file/PathFilter.scala
+++ b/io/src/main/scala/sbt/nio/file/PathFilter.scala
@@ -1,0 +1,259 @@
+/*
+ * sbt IO
+ *
+ * Copyright 2011 - 2019, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ */
+
+package sbt.nio.file
+
+import java.io.FileFilter
+import java.nio.file.{ Files, Path }
+
+/**
+ * A filter for a path and its attributes.
+ */
+trait PathFilter {
+
+  /**
+   *
+   * @param path the path name
+   * @param attributes the file attributes corresponding to `path`
+   * @return true if the filter accepts the path
+   */
+  def accept(path: Path, attributes: FileAttributes): Boolean
+}
+
+object PathFilter {
+
+  /**
+   * Returns a PathFilter that accepts any path for which there exists a [[Glob]] that matches
+   * the path
+   * @param globs the glob patterns
+   * @return a PathFilter that accepts any path matching one or more input [[Glob]]s.
+   */
+  def apply(globs: Glob*): PathFilter = if (globs.isEmpty) NoPass else new GlobPathFilter(globs)
+
+  /**
+   * Provides extension methods for [[PathFilter]]
+   * @param pathFilter the [[PathFilter]] to extend
+   */
+  implicit class Ops(val pathFilter: PathFilter) extends AnyVal {
+
+    /**
+     * Returns a combined [[PathFilter]] that returns true only if both [[PathFilter]] instances
+     * accept the path.
+     * @param other the other [[PathFilter]]
+     */
+    def &&(other: PathFilter): PathFilter = pathFilter match {
+      case NoPass  => NoPass
+      case AllPass => other
+      case f =>
+        other match {
+          case NoPass  => NoPass
+          case AllPass => f
+          case g       => new AndPathFilter(f, g)
+        }
+    }
+
+    /**
+     * Returns a combined [[PathFilter]] that returns true only if both [[PathFilter]] instances
+     * accept the path.
+     * @param other the other [[PathFilter]]
+     */
+    def ||(other: PathFilter): PathFilter = pathFilter match {
+      case NoPass  => other
+      case AllPass => AllPass
+      case f =>
+        other match {
+          case NoPass  => f
+          case AllPass => AllPass
+          case g       => new OrPathFilter(f, g)
+        }
+    }
+
+    /**
+     * Inverts the [[PathFilter.accept]] method.
+     * @return
+     */
+    def unary_! : PathFilter = pathFilter match {
+      case AllPass         => NoPass
+      case NoPass          => AllPass
+      case HiddenFilter    => NotHiddenFilter
+      case NotHiddenFilter => HiddenFilter
+      case pf              => new NotPathFilter(pf)
+    }
+  }
+
+  /**
+   * Converts an instance of [[sbt.io.FileFilter]] to an [[sbt.nio.file.PathFilter]]. It will
+   * de-structure the [[sbt.io.FileFilter]] if possible to convert it to an equivalent, and
+   * possibly more efficient, [[PathFilter]].
+   *
+   * @param fileFilter the filter to convert
+   * @return the converted.
+   */
+  implicit def fromFileFilter(fileFilter: FileFilter): PathFilter = fileFilter match {
+    case sbt.io.HiddenFileFilter    => HiddenFilter
+    case sbt.io.NotHiddenFileFilter => NotHiddenFilter
+    case sbt.io.AllPassFilter       => AllPass
+    case sbt.io.NothingFilter       => NoPass
+    case sbt.io.DirectoryFilter     => DirectoryFilter
+    case nf: sbt.io.NotFilter       => !fromFileFilter(nf.fileFilter)
+    case af: sbt.io.AndFilter       => fromFileFilter(af.left) && fromFileFilter(af.right)
+    case of: sbt.io.OrFilter        => fromFileFilter(of.left) || fromFileFilter(of.right)
+    case filter =>
+      new PathFilter {
+        override def accept(path: Path, attributes: FileAttributes): Boolean =
+          filter.accept(path.toFile)
+        override def toString: String = s"WrappedFileFilter($filter)"
+      }
+  }
+
+  /**
+   * Converts a function from `Path` to `Boolean` to a [[PathFilter]] by ignoring the
+   * [[FileAttributes]] parameter to [[PathFilter.accept]].
+   * @param filter the function to wrap
+   * @return the [[PathFilter]].
+   */
+  def fromPathPredicate(filter: Path => Boolean): PathFilter =
+    new PathFilter {
+      override def accept(path: Path, attributes: FileAttributes): Boolean = filter(path)
+      override def toString: String = s"WrappedPathPredicate($filter)"
+    }
+
+  /**
+   * Converts a function from `FileAttributes` to `Boolean` to a [[PathFilter]] by ignoring the
+   * `Path` parameter to [[PathFilter.accept]].
+   * @param filter the function to wrap
+   * @return the [[PathFilter]].
+   */
+  def fromAttributePredicate(filter: FileAttributes => Boolean): PathFilter =
+    new PathFilter {
+      override def accept(path: Path, attributes: FileAttributes): Boolean = filter(attributes)
+      override def toString: String = s"WrappedPathPredicate($filter)"
+    }
+}
+
+/**
+ * A [[PathFilter]] that includes only directories.
+ */
+case object DirectoryFilter extends PathFilter {
+
+  /**
+   * Returns true if the `path` is a directory
+   * @param path the path name
+   * @param attributes the file attributes corresponding to `path`
+   * @return true if the path is a directory.
+   */
+  override def accept(path: Path, attributes: FileAttributes): Boolean = attributes.isDirectory
+}
+
+/**
+ * A [[PathFilter]] that includes only regular files.
+ */
+case object RegularFileFilter extends PathFilter {
+
+  /**
+   * Returns true if the `path` is a regular file
+   * @param path the path name
+   * @param attributes the file attributes corresponding to `path`
+   * @return true if the path is a regular file.
+   */
+  override def accept(path: Path, attributes: FileAttributes): Boolean = attributes.isRegularFile
+}
+
+/**
+ * A [[PathFilter]] that includes only hidden files according to
+ * [[https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#isHidden-java.nio.file.Path- Files.isHidden]].
+ */
+case object HiddenFilter extends PathFilter {
+
+  /**
+   * Returns true if the `path` is hidden according to
+   * [[https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#isHidden-java.nio.file.Path- Files.isHidden]].
+   * @param path the path name
+   * @param attributes the file attributes corresponding to `path`
+   * @return true if the file is hidden.
+   */
+  override def accept(path: Path, attributes: FileAttributes): Boolean = Files.isHidden(path)
+}
+
+/**
+ * A [[PathFilter]] that includes only files that are not hidden according to
+ * [[https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#isHidden-java.nio.file.Path- Files.isHidden]].
+ */
+case object NotHiddenFilter extends PathFilter {
+  override def accept(path: Path, attributes: FileAttributes): Boolean = !Files.isHidden(path)
+}
+
+case object AllPass extends PathFilter {
+
+  /**
+   * Always returns true.
+   * @param path the path name
+   * @param attributes the file attributes corresponding to `path`
+   * @return true.
+   */
+  override def accept(path: Path, attributes: FileAttributes): Boolean = true
+}
+
+case object NoPass extends PathFilter {
+
+  /**
+   * Always returns false.
+   * @param path the path name
+   * @param attributes the file attributes corresponding to `path`
+   * @return false.
+   */
+  override def accept(path: Path, attributes: FileAttributes): Boolean = false
+}
+
+private[sbt] class AndPathFilter(private val left: PathFilter, private val right: PathFilter)
+    extends PathFilter {
+  override def accept(path: Path, attributes: FileAttributes): Boolean =
+    left.accept(path, attributes) && right.accept(path, attributes)
+  override def equals(obj: Any): Boolean = obj match {
+    case that: AndPathFilter => this.left == that.left && this.right == that.right
+    case _                   => false
+  }
+  override def hashCode(): Int = (left.## * 31) ^ right.##
+  override def toString: String = s"$left && $right"
+}
+
+private[sbt] class OrPathFilter(private val left: PathFilter, private val right: PathFilter)
+    extends PathFilter {
+  override def accept(path: Path, attributes: FileAttributes): Boolean =
+    left.accept(path, attributes) || right.accept(path, attributes)
+  override def hashCode: Int = (left.## * 31) ^ right.##
+  override def equals(obj: Any): Boolean = obj match {
+    case that: OrPathFilter => this.left == that.left && this.right == that.right
+    case _                  => false
+  }
+  override def toString: String = s"$left || $right"
+}
+
+private[sbt] class NotPathFilter(private val filter: PathFilter) extends PathFilter {
+  override def accept(path: Path, attributes: FileAttributes): Boolean =
+    !filter.accept(path, attributes)
+  override def equals(obj: Any): Boolean = obj match {
+    case that: NotPathFilter => this.filter == that.filter
+    case _                   => false
+  }
+  override def hashCode: Int = filter.##
+  override def toString: String = s"!$filter"
+}
+
+private[sbt] class GlobPathFilter(private val globs: Seq[Glob]) extends PathFilter {
+  override def accept(path: Path, attributes: FileAttributes): Boolean =
+    globs.exists(_.matches(path))
+  override def equals(obj: Any): Boolean = obj match {
+    case that: GlobPathFilter => this.globs == that.globs
+    case _                    => false
+  }
+  override def hashCode(): Int = globs.##
+  override def toString: String = s"GlobPathFilter($globs)"
+}

--- a/io/src/test/scala/sbt/internal/nio/GlobsSpec.scala
+++ b/io/src/test/scala/sbt/internal/nio/GlobsSpec.scala
@@ -17,9 +17,10 @@ import org.scalatest.FlatSpec
 import sbt.io._
 import sbt.nio.TestHelpers._
 import sbt.nio.file.RelativeGlob.{ Matcher, NoPath }
-import sbt.nio.file._
+import sbt.nio.file.{ **, AnyPath, Glob }
 
 class GlobsSpec extends FlatSpec {
+
   "FullFileGlob" should "apply exact name filters" in {
     assert(Globs(basePath, recursive = true, "foo") == Glob(basePath, ** / "foo"))
     assert(Globs(basePath, recursive = false, "foo") == Glob(basePath, "foo"))

--- a/io/src/test/scala/sbt/nio/FileTreeViewSpec.scala
+++ b/io/src/test/scala/sbt/nio/FileTreeViewSpec.scala
@@ -17,12 +17,12 @@ import sbt.io.IO
 import sbt.nio.file.{
   **,
   AnyPath,
-  DirectoryFilter,
+  IsDirectory,
   FileAttributes,
   FileTreeView,
   Glob,
   RecursiveGlob,
-  RegularFileFilter
+  IsRegularFile
 }
 import sbt.nio.file.syntax._
 
@@ -96,10 +96,10 @@ class FileTreeViewSpec extends FlatSpec {
     val nestedFile = Files.createFile(nested.resolve("file"))
     val glob = Glob(dir.toPath, RecursiveGlob)
 
-    val files = FileTreeView.default.list(glob, RegularFileFilter)
+    val files = FileTreeView.default.list(glob, IsRegularFile)
     assert(files.map(_._1) == Seq(subdirFile, nestedFile))
 
-    val directories = FileTreeView.default.list(glob, DirectoryFilter)
+    val directories = FileTreeView.default.list(glob, IsDirectory)
     assert(directories.map(_._1) == Seq(subdir, nested))
   }
   it should "handle exact file glob" in IO.withTemporaryDirectory { dir =>

--- a/io/src/test/scala/sbt/nio/FileTreeViewSpec.scala
+++ b/io/src/test/scala/sbt/nio/FileTreeViewSpec.scala
@@ -65,6 +65,19 @@ class FileTreeViewSpec extends FlatSpec {
       .map { case (p, _) => p }
     assert(xs.contains(fooFile) && xs.contains(barFile))
   }
+  it should "list directories only once" in IO.withTemporaryDirectory { dir =>
+    val file1 = Files.createFile(dir.toPath.resolve("file-1"))
+    val file2 = Files.createFile(dir.toPath.resolve("file-2"))
+    val listed = new mutable.ArrayBuffer[Path]
+    val view: FileTreeView.Nio[FileAttributes] = (path: Path) => {
+      val res = FileTreeView.default.list(path)
+      listed += path
+      res
+    }
+    val paths = view.list(Seq(Glob(file1), Glob(file2))).map(_._1)
+    assert(paths.toSet == Set(file1, file2))
+    assert(listed == Seq(file1.getParent))
+  }
   "iterator" should "be lazy" in IO.withTemporaryDirectory { dir =>
     val firstSubdir = Files.createDirectory(dir.toPath.resolve("first"))
     val firstSubdirFile = Files.createFile(firstSubdir.resolve("first-file"))

--- a/io/src/test/scala/sbt/nio/FileTreeViewSpec.scala
+++ b/io/src/test/scala/sbt/nio/FileTreeViewSpec.scala
@@ -78,6 +78,19 @@ class FileTreeViewSpec extends FlatSpec {
     assert(paths.toSet == Set(file1, file2))
     assert(listed == Seq(file1.getParent))
   }
+  it should "apply filters" in IO.withTemporaryDirectory { dir =>
+    val subdir = Files.createDirectories(dir.toPath.resolve("subdir"))
+    val nested = Files.createDirectories(subdir.resolve("nested"))
+    val subdirFile = Files.createFile(subdir.resolve("file"))
+    val nestedFile = Files.createFile(nested.resolve("file"))
+    val glob = Glob(dir.toPath, RecursiveGlob)
+
+    val files = FileTreeView.default.list(glob, (_: Path, a: FileAttributes) => a.isRegularFile)
+    assert(files.map(_._1) == Seq(subdirFile, nestedFile))
+
+    val directories = FileTreeView.default.list(glob, (_: Path, a: FileAttributes) => a.isDirectory)
+    assert(directories.map(_._1) == Seq(subdir, nested))
+  }
   "iterator" should "be lazy" in IO.withTemporaryDirectory { dir =>
     val firstSubdir = Files.createDirectory(dir.toPath.resolve("first"))
     val firstSubdirFile = Files.createFile(firstSubdir.resolve("first-file"))

--- a/io/src/test/scala/sbt/nio/FileTreeViewSpec.scala
+++ b/io/src/test/scala/sbt/nio/FileTreeViewSpec.scala
@@ -14,7 +14,15 @@ import java.nio.file._
 
 import org.scalatest.FlatSpec
 import sbt.io.IO
-import sbt.nio.file.{ AnyPath, FileAttributes, FileTreeView, Glob, RecursiveGlob }
+import sbt.nio.file.{
+  AnyPath,
+  DirectoryFilter,
+  FileAttributes,
+  FileTreeView,
+  Glob,
+  RecursiveGlob,
+  RegularFileFilter
+}
 
 import scala.collection.mutable
 
@@ -85,10 +93,10 @@ class FileTreeViewSpec extends FlatSpec {
     val nestedFile = Files.createFile(nested.resolve("file"))
     val glob = Glob(dir.toPath, RecursiveGlob)
 
-    val files = FileTreeView.default.list(glob, (_: Path, a: FileAttributes) => a.isRegularFile)
+    val files = FileTreeView.default.list(glob, RegularFileFilter)
     assert(files.map(_._1) == Seq(subdirFile, nestedFile))
 
-    val directories = FileTreeView.default.list(glob, (_: Path, a: FileAttributes) => a.isDirectory)
+    val directories = FileTreeView.default.list(glob, DirectoryFilter)
     assert(directories.map(_._1) == Seq(subdir, nested))
   }
   "iterator" should "be lazy" in IO.withTemporaryDirectory { dir =>
@@ -108,7 +116,7 @@ class FileTreeViewSpec extends FlatSpec {
       ListingFileTreeView.iterator(Glob(dir, RecursiveGlob)).collectFirst {
         case (p, a) if a.isRegularFile => p
       }
-    assert(firstSubdirFoundFile.map(_.getParent) == Some(firstSubdir))
+    assert(firstSubdirFoundFile.map(_.getParent).contains(firstSubdir))
     assert(ListingFileTreeView.listed.toSet == Set(dir.toPath, firstSubdir))
     val allFiles = ListingFileTreeView
       .iterator(Glob(dir, RecursiveGlob))

--- a/io/src/test/scala/sbt/nio/PathFilterSpec.scala
+++ b/io/src/test/scala/sbt/nio/PathFilterSpec.scala
@@ -1,0 +1,104 @@
+/*
+ * sbt IO
+ *
+ * Copyright 2011 - 2019, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ */
+
+package sbt.nio
+
+import java.nio.file.{ Files, LinkOption, Path }
+
+import org.scalatest.FlatSpec
+import sbt.io.IO
+import sbt.nio.file.syntax._
+import sbt.nio.file._
+
+object PathFilterSpec {
+  implicit class PathFilterOps(val pathFilter: PathFilter) extends AnyVal {
+    def accept(path: Path): Boolean = FileAttributes(path) match {
+      case Left(_)  => pathFilter.accept(path, FileAttributes.NonExistent)
+      case Right(a) => pathFilter.accept(path, a)
+    }
+  }
+  private val isWin = scala.util.Properties.isWin
+  implicit class PathOps(val path: Path) extends AnyVal {
+    def setHidden(): Path =
+      if (isWin) {
+        Files.setAttribute(path, "dos:hidden", java.lang.Boolean.TRUE, LinkOption.NOFOLLOW_LINKS)
+      } else path
+  }
+}
+import sbt.nio.PathFilterSpec._
+class PathFilterSpec extends FlatSpec {
+  "PathFilters" should "accept files" in IO.withTemporaryDirectory { dir =>
+    val dirPath = dir.toPath
+    val foo = Files.createFile(dirPath / "foo")
+    val fooTxt = dirPath / "foo.txt"
+    val fooScala = Files.createFile(Files.createDirectories(dirPath / "bar") / "foo.scala")
+    assert(AllPass.accept(foo))
+    assert(AllPass.accept(fooTxt))
+    assert(AllPass.accept(fooScala))
+    assert(!(!AllPass).accept(foo))
+    assert(!(!AllPass).accept(fooTxt))
+    assert(!(!AllPass).accept(fooScala))
+  }
+  they should "exclude files" in IO.withTemporaryDirectory { dir =>
+    val dirPath = dir.toPath
+    assert(!NoPass.accept(Files.createFile(dirPath / "foo")))
+    assert(!NoPass.accept(dirPath / "foo.txt"))
+    assert(!NoPass.accept(Files.createFile(Files.createDirectories(dirPath / "bar") / "foo.scala")))
+  }
+  they should "combine filters with &&" in IO.withTemporaryDirectory { dir =>
+    val dirPath = dir.toPath
+    val hidden = Files.createFile(dirPath / ".hidden.scala").setHidden()
+    val foo = Files.createFile(dirPath / "foo.scala")
+    val scalaFilter = PathFilter(dirPath.toGlob / "*.scala")
+    assert(scalaFilter.accept(hidden))
+    assert(scalaFilter.accept(foo))
+    assert(!(scalaFilter && NotHiddenFilter).accept(hidden))
+    assert((scalaFilter && NotHiddenFilter).accept(foo))
+    assert(!(scalaFilter && !HiddenFilter).accept(hidden))
+    assert((scalaFilter && !HiddenFilter).accept(foo))
+    assert((scalaFilter && HiddenFilter).accept(hidden))
+    assert(!(scalaFilter && HiddenFilter).accept(foo))
+  }
+  they should "combine filters with ||" in IO.withTemporaryDirectory { dir =>
+    val dirPath = dir.toPath
+    val foo = Files.createFile(dirPath / "foo.scala")
+    val bar = Files.createFile(dirPath / "bar.java")
+    val scalaFilter = PathFilter(dirPath.toGlob / "*.scala")
+    val javaFilter = PathFilter(dirPath.toGlob / "*.java")
+    assert(scalaFilter.accept(foo))
+    assert(!scalaFilter.accept(bar))
+    assert(!javaFilter.accept(foo))
+    assert(javaFilter.accept(bar))
+    assert((scalaFilter || javaFilter).accept(foo))
+    assert((scalaFilter || javaFilter).accept(bar))
+  }
+  they should "convert file filters" in IO.withTemporaryDirectory { dir =>
+    val hiddenFileFilter: PathFilter = sbt.io.HiddenFileFilter
+    val notHiddenFileFilter: PathFilter = -sbt.io.HiddenFileFilter
+    val dirPath = dir.toPath
+    val hidden = Files.createFile(dirPath / ".hidden.scala").setHidden()
+    val regular = Files.createFile(dirPath / "foo.scala")
+    assert(hiddenFileFilter.accept(hidden))
+    assert((!hiddenFileFilter).accept(regular))
+    assert(notHiddenFileFilter.accept(regular))
+    assert((!notHiddenFileFilter).accept(hidden))
+
+    val directoryFilterAndHidden: PathFilter = sbt.io.DirectoryFilter && sbt.io.HiddenFileFilter
+    val hiddenDir = Files.createDirectories(dirPath / ".hidden").setHidden()
+    assert(directoryFilterAndHidden.accept(hiddenDir) == !isWin)
+    assert(!directoryFilterAndHidden.accept(dirPath))
+    assert(!directoryFilterAndHidden.accept(hidden))
+
+    val directoryFilterOrHidden: PathFilter = sbt.io.DirectoryFilter || sbt.io.HiddenFileFilter
+    assert(directoryFilterOrHidden.accept(hiddenDir))
+    assert(directoryFilterOrHidden.accept(dirPath))
+    assert(directoryFilterOrHidden.accept(hidden))
+  }
+}

--- a/io/src/test/scala/sbt/nio/PathFilterSpec.scala
+++ b/io/src/test/scala/sbt/nio/PathFilterSpec.scala
@@ -92,9 +92,8 @@ class PathFilterSpec extends FlatSpec {
     )
   }
   they should "combine file filters" in IO.withTemporaryDirectory { dir =>
-    import sbt.io.syntax._
-    val notHiddenFileFilter: PathFilter = -sbt.io.HiddenFileFilter
-    val hiddenFileFilter: PathFilter = !notHiddenFileFilter
+    val notHiddenFileFilter: PathFilter = !sbt.io.HiddenFileFilter
+    val hiddenFileFilter: PathFilter = sbt.io.HiddenFileFilter
     val dirPath = dir.toPath
     val hidden = Files.createFile(dirPath / ".hidden.scala").setHidden()
     val regular = Files.createFile(dirPath / "foo.scala")
@@ -103,13 +102,15 @@ class PathFilterSpec extends FlatSpec {
     assert(notHiddenFileFilter.accept(regular))
     assert((!notHiddenFileFilter).accept(hidden))
 
-    val directoryFilterAndHidden: PathFilter = sbt.io.DirectoryFilter && sbt.io.HiddenFileFilter
+    val directoryFilterAndHidden
+        : PathFilter = sbt.io.DirectoryFilter.toNio && sbt.io.HiddenFileFilter
     val hiddenDir = Files.createDirectories(dirPath / ".hidden").setHidden()
     assert(directoryFilterAndHidden.accept(hiddenDir) == !isWin)
     assert(!directoryFilterAndHidden.accept(dirPath))
     assert(!directoryFilterAndHidden.accept(hidden))
 
-    val directoryFilterOrHidden: PathFilter = sbt.io.DirectoryFilter || sbt.io.HiddenFileFilter
+    val directoryFilterOrHidden: PathFilter =
+      sbt.io.DirectoryFilter.toNio || sbt.io.HiddenFileFilter
     assert(directoryFilterOrHidden.accept(hiddenDir))
     assert(directoryFilterOrHidden.accept(dirPath))
     assert(directoryFilterOrHidden.accept(hidden))


### PR DESCRIPTION
This adds the `PathFilter` trait, which is effectively `(Path, FileAttributes) => Boolean` and is used with the `Glob`/`fileTreeView` dsl similarly to the `sbt.io.FileFilter` for the `PathFinder` dsl.