### PR TITLE
Add retries to FileTreeView.list

### DIFF
--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -587,7 +587,7 @@ object IO {
           catch { case _: IOException => }
       }
     } catch {
-      case _: NotDirectoryException | _: NoSuchFileException =>
+      case _: IOException => // Silently fail to preserve legacy behavior.
     }
     try Files.deleteIfExists(file.toPath)
     catch { case _: IOException => }

--- a/io/src/test/scala/sbt/io/IOSpec.scala
+++ b/io/src/test/scala/sbt/io/IOSpec.scala
@@ -209,6 +209,12 @@ class IOSpec extends FunSuite {
     assert(s.startsWith("file:") && s.endsWith("/sbt/io/IOSpec.class"))
   }
 
+  test("delete should handle non-existent files") {
+    IO.withTemporaryDirectory { dir =>
+      IO.delete(new File(dir, "foo"))
+    }
+  }
+
   def normalizeForWindows(s: String): String = {
     s.replaceAllLiterally("""\""", "/")
   }

--- a/io/src/test/scala/sbt/nio/FileTreeViewSpec.scala
+++ b/io/src/test/scala/sbt/nio/FileTreeViewSpec.scala
@@ -118,6 +118,16 @@ class FileTreeViewSpec extends FlatSpec {
     val globs = (1 to n).map(i => dir.toGlob / "subdir" / "nested" / s"a$i") :+ Glob(dir, ** / "b*")
     assert(randomFiles.toSet == FileTreeView.default.list(globs).map(_._1).toSet)
   }
+  it should "throw NoSuchFileException for non-existent directories" in IO.withTemporaryDirectory {
+    dir =>
+      intercept[NoSuchFileException](FileTreeView.nio.list(dir.toPath / "foo"))
+      intercept[NoSuchFileException](FileTreeView.native.list(dir.toPath / "foo"))
+  }
+  it should "throw NotDirectoryException for regular files" in IO.withTemporaryDirectory { dir =>
+    val file = Files.createFile(dir.toPath / "file")
+    intercept[NotDirectoryException](FileTreeView.nio.list(file))
+    intercept[NotDirectoryException](FileTreeView.native.list(file))
+  }
   "iterator" should "be lazy" in IO.withTemporaryDirectory { dir =>
     val firstSubdir = Files.createDirectory(dir.toPath.resolve("first"))
     val firstSubdirFile = Files.createFile(firstSubdir.resolve("first-file"))


### PR DESCRIPTION
In 52cb29be7f911d73e501f52b76659d8efd6ad49c, we stopped catching all
exceptions in FileTreeView.list. This exposed an issue on windows where
sometimes an AccessDeniedException was thrown but what was quietly
ignored. To work around this, add retries when neither
NotDirectoryException nor NoSuchFileException are thrown. This is
really just to handle AccessDeniedExceptions on Windows.