### PR TITLE
Apply DeMorgan's rule to not filters

### DIFF
--- a/io/src/test/scala/sbt/nio/PathFilterSpec.scala
+++ b/io/src/test/scala/sbt/nio/PathFilterSpec.scala
@@ -126,4 +126,38 @@ class PathFilterSpec extends FlatSpec {
     assert(!(!notBar).accept(foo))
     assert((!notBar).accept(bar))
   }
+  they should "negate" in IO.withTemporaryDirectory { dir =>
+    val dirPath = dir.toPath
+    val foo = Files.createFile(dirPath / "foo.txt")
+    val hidden = Files.createFile(dirPath / ".hidden").setHidden
+    val filter = IsDirectory && !IsHidden
+    val notFilter = !filter
+    assert(notFilter == (!IsDirectory || IsHidden))
+    assert(!filter.accept(foo))
+    assert(!filter.accept(hidden))
+    assert(filter.accept(dirPath))
+    assert(notFilter.accept(foo))
+    assert(notFilter.accept(hidden))
+    assert(!notFilter.accept(dirPath))
+
+    val tripleAndFilter = IsDirectory && !IsHidden && !(** / "*.txt")
+    val notTripleAndFilter = !tripleAndFilter
+    assert(notTripleAndFilter == (!IsDirectory || IsHidden || (** / "*.txt")))
+    assert(!(tripleAndFilter.accept(foo)))
+    assert(tripleAndFilter.accept(dirPath))
+    assert(!(tripleAndFilter.accept(hidden)))
+    assert(notTripleAndFilter.accept(foo))
+    assert(notTripleAndFilter.accept(hidden))
+    assert(!(notTripleAndFilter.accept(dirPath)))
+
+    val tripleOrFilter = IsDirectory || IsHidden || (** / "*.txt")
+    val notTripleOrFilter = !tripleOrFilter
+    assert(notTripleOrFilter == (!IsDirectory && !IsHidden && !(** / "*.txt")))
+    assert(tripleOrFilter.accept(foo))
+    assert(tripleOrFilter.accept(hidden))
+    assert(tripleOrFilter.accept(dirPath))
+    assert(!(notTripleOrFilter.accept(foo)))
+    assert(!(notTripleOrFilter.accept(hidden)))
+    assert(!(notTripleOrFilter.accept(dirPath)))
+  }
 }


### PR DESCRIPTION
I noticed that while the unary `!` operator worked correctly in sbt, the
toString looked wrong because NotPathFilter toString was defined as:
`override def toString: String = !filter`
When the filter was an || filter, this turned into something like
!DirectoryFilter || HiddenFileFilter
which was confusing because it actually represented
!(DirectoryFilter || HiddenFileFilter)

When I thought about it, I realized it would be nicer to just apply
DeMorgan's rules in the NotFilter. The filter then becomes:
!DirectoryFilter && !HiddenFileFilter
which I think is easier to read anyway.