### PR TITLE
Close stream used in FileTreeView.nio

### DIFF
--- a/io/src/main/scala/sbt/nio/file/FileTreeView.scala
+++ b/io/src/main/scala/sbt/nio/file/FileTreeView.scala
@@ -56,8 +56,9 @@ object FileTreeView {
   val nio: FileTreeView.Nio[FileAttributes] = (path: Path) =>
     Retry(
       {
-        val paths = Files.list(path).iterator.asScala
-        paths.flatMap(p => FileAttributes(p).toOption.map(p -> _)).toIndexedSeq
+        val stream = Files.list(path)
+        try stream.iterator.asScala.flatMap(p => FileAttributes(p).toOption.map(p -> _)).toVector
+        finally stream.close()
       },
       classOf[NotDirectoryException],
       classOf[NoSuchFileException]


### PR DESCRIPTION
We created a stream without closing it. This came up because I was
reading the release notes for metals 0.7.2 and they mentioned fixing a
similar bug in the release notes.

In general, the nio FileTreeView should not really be in use in sbt
1.3.0. It would only be used on 32 bit platforms running sbt. Because
FileTreeView is a new api, and I rolled back the default path finder
implementations, none of the downstream consumers should be affected.