### PR TITLE
Fixes acquiring timestamp from a file with long path name on Windows

### DIFF
--- a/io/src/main/scala/sbt/internal/io/Milli.scala
+++ b/io/src/main/scala/sbt/internal/io/Milli.scala
@@ -263,7 +263,7 @@ private object WinMilli extends MilliNative[FILETIME] {
 
   private def getHandle(lpFileName: String, dwDesiredAccess: Int, dwShareMode: Int): HANDLE = {
     val hFile = CreateFile(
-      lpFileName,
+      "\\\\?\\" + lpFileName,
       dwDesiredAccess,
       dwShareMode,
       null,

--- a/io/src/main/scala/sbt/internal/io/Milli.scala
+++ b/io/src/main/scala/sbt/internal/io/Milli.scala
@@ -28,6 +28,7 @@ import sbt.io.JavaMilli
 
 import scala.collection.JavaConverters.mapAsJavaMapConverter
 import scala.reflect.{ ClassTag, classTag }
+import scala.util.control.NonFatal
 
 private abstract class Stat[Time_T](size: Int) extends NativeMapped {
   val buffer = ByteBuffer.allocate(size).order(ByteOrder.nativeOrder())
@@ -341,8 +342,18 @@ object Milli {
   // "false", disable native millisecond-accurate modification timestamps.
   //
   private val jdkTimestamps = {
-    val prop = System.getProperty("sbt.io.jdktimestamps")
-    !(prop eq null) && (prop.toLowerCase != "false")
+    System.getProperty("sbt.io.jdktimestamps") match {
+      case null =>
+        System.getProperty("java.specification.version") match {
+          case null => false
+          case sv =>
+            try sv.split("\\.").last.toInt match {
+              case v if v >= 11 => true
+              case _            => false
+            } catch { case NonFatal(_) => false }
+        }
+      case p => p.toLowerCase != "false"
+    }
   }
 
   private val milli =

--- a/io/src/test/scala/sbt/io/LastModifiedSpec.scala
+++ b/io/src/test/scala/sbt/io/LastModifiedSpec.scala
@@ -1,0 +1,31 @@
+/*
+ * sbt IO
+ *
+ * Copyright 2011 - 2019, Lightbend, Inc.
+ * Copyright 2008 - 2010, Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ */
+
+package sbt.io
+
+import java.nio.file.Files
+
+import org.scalatest.FlatSpec
+
+class LastModifiedSpec extends FlatSpec {
+  "IO.getModifiedTimeOrZero" should "work with long path names" in IO.withTemporaryDirectory {
+    dir =>
+      val fileName = "a" * 32
+      val nested =
+        (1 to 8).foldLeft(dir.toPath) {
+          case (d, _) => Files.createDirectories(d.resolve(fileName))
+        }
+      val file = Files.createFile(nested.resolve(fileName)).toFile
+      // in case target platform only has second precision round to nearest second
+      val lm = (System.currentTimeMillis / 1000) * 1000
+      IO.setModifiedTimeOrFalse(file, lm)
+      assert(IO.getModifiedTimeOrZero(file) == lm)
+  }
+}


### PR DESCRIPTION
Should fix https://github.com/sbt/sbt/issues/5098.