### PR TITLE
Prefer JavaMillis starting from Java 10

### DIFF
--- a/io/src/main/scala/sbt/internal/io/Milli.scala
+++ b/io/src/main/scala/sbt/internal/io/Milli.scala
@@ -344,6 +344,7 @@ object Milli {
   //
   // If the property "sbt.io.jdktimestamps" is set to anything other than
   // "false", disable native millisecond-accurate modification timestamps.
+  // millis were missing until Java 10, see https://bugs.openjdk.java.net/browse/JDK-8177809
   //
   private val jdkTimestamps = {
     System.getProperty("sbt.io.jdktimestamps") match {
@@ -351,9 +352,8 @@ object Milli {
         System.getProperty("java.specification.version") match {
           case null => false
           case sv =>
-            try sv.split("\\.").last.toInt match {
-              case v if v >= 11 => true
-              case _            => false
+            try {
+              sv.split("\\.").last.toInt >= 10
             } catch { case NonFatal(_) => false }
         }
       case p => p.toLowerCase != "false"


### PR DESCRIPTION
Motivation:

JavaMillis is currently only preferred for Java 11+.
But bug that chopped off millis from Files.getLastModifiedTime was fixed in Java 10, see https://bugs.openjdk.java.net/browse/JDK-8177809

Modification:

Have jdkTimestamps evaluate to true for Java 10.

Result:

Milli doesn't use JNA on Java 10.