### PR TITLE
workaround for SDKMAN getting stuck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ before_install:
   # adding $HOME/.sdkman to cache would create an empty directory, which interferes with the initial installation
   - "[[ -d $HOME/.sdkman/bin/ ]] || rm -rf $HOME/.sdkman/"
   - curl -sL https://get.sdkman.io | bash
-  - echo sdkman_auto_answer=true > $HOME/.sdkman/etc/config
+  - echo sdkman_auto_answer=true >> $HOME/.sdkman/etc/config
+  - echo sdkman_auto_selfupdate=true >> $HOME/.sdkman/etc/config
   - source "$HOME/.sdkman/bin/sdkman-init.sh"
   - unset _JAVA_OPTIONS
 


### PR DESCRIPTION
Ref https://github.com/scala/scala/pull/8528

Currently SDKMAN blocks for prompt when there's a new version of SDKMAN. This is an attempted workaround.