### PR TITLE
allow customization of publishTo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -152,6 +152,14 @@ val io = (project in file("io"))
     buildInfoUsePackageAsPath in Test := true,
   )
 
+ThisBuild / publishTo := {
+  val old = (ThisBuild / publishTo).value
+  sys.props.get("sbt.build.localmaven") match {
+    case Some(path) => Some(MavenCache("local-maven", file(path)))
+    case _          => old
+  }
+}
+
 inThisBuild(
   Seq(
     whitesourceProduct := "Lightbend Reactive Platform",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.5")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.2")


### PR DESCRIPTION
sbt-bintray 0.5.6 allows disabling of the plugin. combined with `ThisBuild / publishTo` reading from the system property, this allows

```
sbt -Dsbt.sbtbintray=false -Dsbt.build.localmaven=/tmp/m2/ -Dsbt.build.version=1.4.0-M1-20191226
```