### PR TITLE
[1.3.x] Fix IO.getModifiedTimeOrZero for unnormalized paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,15 +33,16 @@ before_install:
   # adding $HOME/.sdkman to cache would create an empty directory, which interferes with the initial installation
   - "[[ -d $HOME/.sdkman/bin/ ]] || rm -rf $HOME/.sdkman/"
   - curl -sL https://get.sdkman.io | bash
-  - echo sdkman_auto_answer=true > $HOME/.sdkman/etc/config
+  - echo sdkman_auto_answer=true >> $HOME/.sdkman/etc/config
+  - echo sdkman_auto_selfupdate=true >> $HOME/.sdkman/etc/config
   - source "$HOME/.sdkman/bin/sdkman-init.sh"
   - unset _JAVA_OPTIONS
 
 install:
-  - sdk install java $(sdk list java | grep -o "$ADOPTOPENJDK\.[0-9\.]*hs-adpt" | head -1)
+  - sdk install java $(sdk list java | grep -o "$ADOPTOPENJDK\.[0-9\.]*hs-adpt" | head -1) || true
   - unset JAVA_HOME
   - java -Xmx32m -version
-  - sdk install sbt $TRAVIS_SBT
+  - sdk install sbt $TRAVIS_SBT || true
 
 script:
   - sbt -Dsbt.test.fork=true ++$TRAVIS_SCALA212! mimaReportBinaryIssues test

--- a/io/src/main/scala/sbt/internal/io/Milli.scala
+++ b/io/src/main/scala/sbt/internal/io/Milli.scala
@@ -19,6 +19,7 @@ import com.sun.jna.platform.win32.WinBase.{ FILETIME, INVALID_HANDLE_VALUE }
 import com.sun.jna.platform.win32.WinError.{
   ERROR_ACCESS_DENIED,
   ERROR_FILE_NOT_FOUND,
+  ERROR_INVALID_NAME,
   ERROR_PATH_NOT_FOUND
 }
 import com.sun.jna.platform.win32.WinNT._
@@ -277,8 +278,11 @@ private object WinMilli extends MilliNative[FILETIME] {
         throw new FileNotFoundException("Not found: " + lpFileName)
       else if (err == ERROR_ACCESS_DENIED)
         throw new FileNotFoundException("Access denied: " + lpFileName)
-      else
+      else if (err == ERROR_INVALID_NAME)
+        throw new FileNotFoundException("Invalid path name " + lpFileName)
+      else {
         throw new IOException("CreateFile() failed with error " + GetLastError())
+      }
     }
     hFile
   }

--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -1372,7 +1372,10 @@ object IO {
     try {
       Retry(Milli.getModifiedTime(file), classOf[FileNotFoundException])
     } catch {
-      case _: FileNotFoundException => 0L
+      case _: FileNotFoundException =>
+        val unnormalized = file.toPath
+        val normalized = unnormalized.normalize.toAbsolutePath
+        if (unnormalized != normalized) getModifiedTimeOrZero(normalized.toFile) else 0L
     }
 
   /**
@@ -1395,7 +1398,10 @@ object IO {
       Retry(Milli.setModifiedTime(file, mtime), classOf[FileNotFoundException])
       true
     } catch {
-      case _: FileNotFoundException => false
+      case _: FileNotFoundException =>
+        val unnormalized = file.toPath
+        val normalized = unnormalized.normalize.toAbsolutePath
+        if (unnormalized != normalized) setModifiedTimeOrFalse(normalized.toFile, mtime) else false
     }
 
   /**

--- a/io/src/test/scala/sbt/io/LastModifiedSpec.scala
+++ b/io/src/test/scala/sbt/io/LastModifiedSpec.scala
@@ -10,9 +10,10 @@
 
 package sbt.io
 
-import java.nio.file.Files
+import java.nio.file.{ Files, Paths => JPaths }
 
 import org.scalatest.FlatSpec
+import sbt.nio.file.syntax._
 
 class LastModifiedSpec extends FlatSpec {
   "IO.getModifiedTimeOrZero" should "work with long path names" in IO.withTemporaryDirectory {
@@ -27,5 +28,23 @@ class LastModifiedSpec extends FlatSpec {
       val lm = (System.currentTimeMillis / 1000) * 1000
       IO.setModifiedTimeOrFalse(file, lm)
       assert(IO.getModifiedTimeOrZero(file) == lm)
+  }
+  it should "handle empty paths" in {
+    assert(IO.getModifiedTimeOrZero(JPaths.get("").toFile) > 0)
+    val newLM = ((System.currentTimeMillis + 10000) / 1000) * 1000
+    IO.setModifiedTimeOrFalse(JPaths.get("").toFile, newLM)
+    assert(IO.getModifiedTimeOrZero(JPaths.get("").toFile) == newLM)
+  }
+  it should "handle relative paths" in IO.withTemporaryDirectory { dir =>
+    val dirPath = dir.toPath
+    val subDir1 = Files.createDirectories(dirPath / "subdir-1")
+    val subDir2 = Files.createDirectories(dirPath / "subdir-2")
+    val subFile = Files.createFile(subDir2 / "file")
+    val lm = IO.getModifiedTimeOrZero(subFile.toFile)
+    val relative = subDir1 / ".." / subDir2.getFileName.toString / subFile.getFileName.toString
+    assert(IO.getModifiedTimeOrZero(relative.toFile) == lm)
+    val newLM = ((System.currentTimeMillis + 10000) / 1000) * 1000
+    IO.setModifiedTimeOrFalse(relative.toFile, newLM)
+    assert(IO.getModifiedTimeOrZero(relative.toFile) == newLM)
   }
 }


### PR DESCRIPTION
This is a backport of sbt/io#273
Fixes https://github.com/sbt/sbt/issues/5224

## original description

The fix for long path names on windows,
099aa4f, had the unintended side effect
of causing IO.getModifiedTimeOrZero to throw uncaught IOExceptions when
the path name was not normalized. Specifically, it would throw if the
path was empty or if it had relative components. To fix this, we try to
get the modified time but if the file is not found, we normalize the
path and make it absolute and retry.

This change was primarily made for windows, but it turns out that
IO.getModifiedTimeOrZero(file("")) also didn't work correctly. Naively,
I'd expect the empty path to be expanded to the program working
directory but it would actually just return 0 because the posix native
api did not handle empty strings either. Relative paths did work on
posix before this change.