### PR TITLE
Correctly exclude base from Path.allSubpaths result

### DIFF
--- a/io/src/main/scala/sbt/io/PathMapper.scala
+++ b/io/src/main/scala/sbt/io/PathMapper.scala
@@ -112,12 +112,10 @@ abstract class Mapper {
    * Selects descendants of `base` directory matching `filter` and maps them to a path relative to `base`.
    * `base` itself is not included.
    */
-  def selectSubpaths(base: File, filter: FileFilter): Traversable[(File, String)] = {
-    val path = base.toPath
+  def selectSubpaths(base: File, filter: FileFilter): Traversable[(File, String)] =
     PathFinder(base).globRecursive(filter).get().collect {
-      case f if f != path => f -> path.relativize(f.toPath).toString
+      case f if f != base => f -> base.toPath.relativize(f.toPath).toString
     }
-  }
 
   /**
    * return a Seq of mappings which effect is to add a whole directory in the generated package

--- a/io/src/test/scala/sbt/io/PathMapperSpec.scala
+++ b/io/src/test/scala/sbt/io/PathMapperSpec.scala
@@ -128,6 +128,13 @@ class PathMapperSpec extends fixture.FlatSpec with Matchers {
     mappings should be(empty)
   }
 
+  it should "not include the base directory" in { tempDirectory =>
+    val file = Files.createFile(tempDirectory.resolve("file"))
+    val paths = Path.allSubpaths(tempDirectory.toFile).toVector.map(_._1.toPath).toSet
+    assert(paths.contains(file))
+    assert(!paths.contains(tempDirectory))
+  }
+
   override protected def withFixture(test: OneArgTest): Outcome = {
     val tmpDir = Files.createTempDirectory("path-mappings")
     try {


### PR DESCRIPTION
It was reported in https://github.com/scala/scala/pull/8525 that sbt
does not correctly exclude the base directory when calling
Path.allSubpaths. This ended up causing jar files to be created with an
empty entry. The problem was in an incorrect equality check because the
compiler did not flag for us that
`PathFinder(base).globRecursive(filter).get()` returned `Seq[File]` but
that we were filtering the results by comparing a `File` to a `Path`.