### PR TITLE
Expose Milli.milli to let Zinc be more efficient

### DIFF
--- a/io/src/main/scala/sbt/internal/io/Milli.scala
+++ b/io/src/main/scala/sbt/internal/io/Milli.scala
@@ -79,6 +79,7 @@ private abstract class MilliNative[Native] extends Milli {
  * FFI for standard C library.
  */
 private sealed trait PosixBase extends Library {
+
   /** http://www.cplusplus.com/reference/cstring/strerror/ */
   def strerror(errnum: Int): String
 }

--- a/io/src/main/scala/sbt/internal/io/Milli.scala
+++ b/io/src/main/scala/sbt/internal/io/Milli.scala
@@ -368,7 +368,7 @@ object Milli {
     }
   }
 
-  private val milli =
+  val milli: Milli =
     if (jdkTimestamps || !isIntel)
       JavaMilli
     else

--- a/io/src/main/scala/sbt/internal/nio/SwovalConverters.scala
+++ b/io/src/main/scala/sbt/internal/nio/SwovalConverters.scala
@@ -54,7 +54,9 @@ private[sbt] object SwovalFileTreeView extends FileTreeView.Nio[FileAttributes] 
         }
         result.result()
       },
-      classOf[NotDirectoryException],
-      classOf[NoSuchFileException]
+      excludedExceptions: _*
     )
+
+  private val excludedExceptions =
+    List(classOf[NotDirectoryException], classOf[NoSuchFileException])
 }

--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -27,6 +27,7 @@ import sbt.nio.file.FileTreeView
 import scala.Function.tupled
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
+import scala.collection.immutable
 import scala.collection.immutable.TreeSet
 import scala.collection.mutable.{ HashMap, HashSet }
 import scala.reflect.{ Manifest => SManifest }
@@ -1404,7 +1405,7 @@ object IO {
    */
   def getModifiedTimeOrZero(file: File): Long =
     try {
-      Retry(Milli.getModifiedTime(file), classOf[FileNotFoundException])
+      Retry(Milli.getModifiedTime(file), excludeFileNotFound: _*)
     } catch {
       case _: FileNotFoundException =>
         val unnormalized = file.toPath
@@ -1429,7 +1430,7 @@ object IO {
    */
   def setModifiedTimeOrFalse(file: File, mtime: Long): Boolean =
     try {
-      Retry(Milli.setModifiedTime(file, mtime), classOf[FileNotFoundException])
+      Retry(Milli.setModifiedTime(file, mtime), excludeFileNotFound: _*)
       true
     } catch {
       case _: FileNotFoundException =>
@@ -1461,4 +1462,8 @@ object IO {
     // see Java bug #6791812
     setModifiedTimeOrFalse(targetFile, math.max(last, 0L))
   }
+
+  private val excludeFileNotFound: immutable.Seq[Class[_ <: IOException]] = List(
+    classOf[FileNotFoundException]
+  )
 }

--- a/io/src/main/scala/sbt/nio/file/FileTreeView.scala
+++ b/io/src/main/scala/sbt/nio/file/FileTreeView.scala
@@ -53,16 +53,18 @@ object FileTreeView {
    * An implementation of [[FileTreeView]] that uses built in jvm apis. This implementation
    * will throw an IOException if the input path is not a directory or doesn't exist.
    */
-  val nio: FileTreeView.Nio[FileAttributes] = (path: Path) =>
-    Retry(
-      {
-        val stream = Files.list(path)
-        try stream.iterator.asScala.flatMap(p => FileAttributes(p).toOption.map(p -> _)).toVector
-        finally stream.close()
-      },
-      classOf[NotDirectoryException],
-      classOf[NoSuchFileException]
-    )
+  val nio: FileTreeView.Nio[FileAttributes] = {
+    val excludedExceptions = List(classOf[NotDirectoryException], classOf[NoSuchFileException])
+    (path: Path) =>
+      Retry(
+        {
+          val stream = Files.list(path)
+          try stream.iterator.asScala.flatMap(p => FileAttributes(p).toOption.map(p -> _)).toVector
+          finally stream.close()
+        },
+        excludedExceptions: _*
+      )
+  }
 
   /**
    * Adds additional methods to [[FileTreeView]]. This api may be changed so it should not be


### PR DESCRIPTION
It can avoid the allocation of the `Path` => `File` conversion
and also save extra calls to `readAttribute` when we are using
`JavaMillis`.