### PR TITLE
sleep for 100 msec betwen retries

### DIFF
--- a/io/src/main/scala/sbt/internal/io/Retry.scala
+++ b/io/src/main/scala/sbt/internal/io/Retry.scala
@@ -41,8 +41,9 @@ private[sbt] object Retry {
       } catch {
         case e: IOException if filter(e) =>
           if (firstException == null) firstException = e
-
-          Thread.sleep(0);
+          // https://github.com/sbt/io/issues/295
+          // On Windows, we're seeing java.nio.file.AccessDeniedException with sleep(0).
+          Thread.sleep(100)
           attempt += 1
       }
     }


### PR DESCRIPTION
Fixes https://github.com/sbt/io/issues/295

From experimenting on sbt/sbt https://github.com/sbt/sbt/pull/5543, sleeping 100 msec would seem to fix the `java.nio.file.AccessDeniedException` error we started seeing recently on AppVeyor.
