### PR TITLE
Relax anti-entropy quarantine constraint

### DIFF
--- a/io/src/main/scala/sbt/internal/nio/FileEventMonitor.scala
+++ b/io/src/main/scala/sbt/internal/nio/FileEventMonitor.scala
@@ -270,7 +270,7 @@ private[sbt] object FileEventMonitor {
               Some(Update(path, oldAttributes, attributes, d.occurredAt))
             case _ =>
               antiEntropyDeadlines.get(path) match {
-                case Some(deadline) if occurredAt <= deadline =>
+                case Some(deadline) if occurredAt < deadline =>
                   val msg = s"Discarding entry for recently updated path $path. " +
                     s"This event occurred ${(occurredAt - (deadline - period)).toMillis} ms since " +
                     "the last event for this path."


### PR DESCRIPTION
In sbt scripted tests, it was possible for files to trigger a few times
with the same timestamp which would cause the anti entropy file event
monitor to drop the event even if the anti-entropy period was set to
zero. This could be worked around with a negative anti-entropy period,
but this seems like a better fix.