### PR TITLE
Bump swoval version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,6 +11,6 @@ object Dependencies {
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.8"
   val jna = "net.java.dev.jna" % "jna" % "5.5.0"
   val jnaPlatform = "net.java.dev.jna" % "jna-platform" % "5.5.0"
-  val swovalFiles = "com.swoval" % "file-tree-views" % "2.1.3"
+  val swovalFiles = "com.swoval" % "file-tree-views" % "2.1.4"
   def nightlyVersion: Option[String] = sys.props.get("sbt.build.version")
 }


### PR DESCRIPTION
The swoval file watcher didn't work as expected on linux and windows
when we monitored a directory that wasn't yet created:
https://github.com/swoval/swoval/pull/135/commits/381f426e015def1c51e181274e6dd9bf3a5ad786.
This is an edge case that is probably fairly rare but still worth
addressing. Say that you wanted to monitor only the
directory /tmp/foo/bar/baz but only /tmp exists. On mac, if the user
created /tmp/foo/bar/baz and then added a file
/tmp/foo/bar/baz/buzz.txt, it would trigger. It would not have triggered
on linux and windows because older versions of swoval would detect the
creation of /tmp/foo, but wouldn't watch it. This would make it miss the
creation of /tmp/foo/bar and then /tmp/foo/bar/baz. The 2.1.4 version
fixes this behavior. In sbt, a user might see this if they created a new
project and ran ~compile before they created the directory
src/main/scala.

The issue in swoval was discovered as part of a PR to metals:
https://github.com/scalameta/metals/pull/2014