### PR TITLE
Fix sbt bug #6453

### DIFF
--- a/io/src/main/scala/sbt/nio/file/FileTreeView.scala
+++ b/io/src/main/scala/sbt/nio/file/FileTreeView.scala
@@ -372,7 +372,7 @@ object FileTreeView {
                   case Some((`p`, m)) =>
                     m.get(path) match {
                       case null               =>
-                      case a if a.isDirectory => listPath(p)
+                      case a if a.isDirectory => listPath(path)
                       case a                  => maybeAdd(path -> a)
                     }
                   case _ => listPath(path)

--- a/io/src/test/scala/sbt/nio/FileTreeViewSpec.scala
+++ b/io/src/test/scala/sbt/nio/FileTreeViewSpec.scala
@@ -118,6 +118,15 @@ class FileTreeViewSpec extends FlatSpec {
     val globs = (1 to n).map(i => dir.toGlob / "subdir" / "nested" / s"a$i") :+ Glob(dir, ** / "b*")
     assert(randomFiles.toSet == FileTreeView.default.list(globs).map(_._1).toSet)
   }
+  it should "handle overlapping globs with exact file" in IO.withTemporaryDirectory { dir =>
+    val subdir = Files.createDirectories(dir.toPath / "subdir")
+    val nested = Files.createDirectories(subdir / "nested")
+    val a = Files.createFile(subdir / "a.txt")
+    val b = Files.createFile(nested / "b.txt")
+    val globs = Seq(Glob(subdir, "a.txt"), Glob(nested, RecursiveGlob))
+    val queried = FileTreeView.default.list(globs).map(_._1).toSet
+    assert(queried == Set(a, b))
+  }
   it should "throw NoSuchFileException for non-existent directories" in IO.withTemporaryDirectory {
     dir =>
       intercept[NoSuchFileException](FileTreeView.nio.list(dir.toPath / "foo"))


### PR DESCRIPTION
A user pointed out that if two globs were specificed that looked like
a/b.txt and a/b/**, then FileTreeView.list(globs) would not return the
children in the subdirectory a/b. There is an optimization that
FileTreeView.list makes when handling paths that may have multiple globs
matching the same prefix. At the fork point (which in the example above
is the directory a), we save all of the files that we find in there so
that as the recursive algorithm proceeds, it doesn't necessarily need to
make an additional syscall to determine whether the next file it wants
to look at is a path or a directory. The problem here though was that we
incorrectly passed the parent (fork) path into the listPath method
rather than the path itself.