### PR TITLE
Add hardLink to CopyOptions and related copyFile/copyDirectory helpers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ ThisBuild / version := {
   (sys.env.get("BUILD_VERSION") orElse sys.props.get("sbt.build.version")) match {
     case Some(v) => v
     case _ =>
-      if ((ThisBuild / isSnapshot).value) "1.4.0-SNAPSHOT"
+      if ((ThisBuild / isSnapshot).value) "1.6.0-SNAPSHOT"
       else old
   }
 }

--- a/io/src/main/contraband-scala/sbt/io/CopyOptions.scala
+++ b/io/src/main/contraband-scala/sbt/io/CopyOptions.scala
@@ -12,26 +12,29 @@ package sbt.io
                     If the source is a directory, the corresponding directory is created.
  * @param preserveLastModified If `true` the last modified times are copied.
  * @param preserveExecutable If `true` the executable properties are copied.
+ * @param hardLink If 'true' the copy is a hardlink.
  */
 final class CopyOptions private (
   val overwrite: Boolean,
   val preserveLastModified: Boolean,
-  val preserveExecutable: Boolean) extends Serializable {
+  val preserveExecutable: Boolean,
+  val hardLink: Boolean) extends Serializable {
   
-  private def this() = this(false, false, true)
+  private def this() = this(false, false, true, false)
+  private def this(overwrite: Boolean, preserveLastModified: Boolean, preserveExecutable: Boolean) = this(overwrite, preserveLastModified, preserveExecutable, false)
   
   override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
-    case x: CopyOptions => (this.overwrite == x.overwrite) && (this.preserveLastModified == x.preserveLastModified) && (this.preserveExecutable == x.preserveExecutable)
+    case x: CopyOptions => (this.overwrite == x.overwrite) && (this.preserveLastModified == x.preserveLastModified) && (this.preserveExecutable == x.preserveExecutable) && (this.hardLink == x.hardLink)
     case _ => false
   })
   override def hashCode: Int = {
-    37 * (37 * (37 * (37 * (17 + "sbt.io.CopyOptions".##) + overwrite.##) + preserveLastModified.##) + preserveExecutable.##)
+    37 * (37 * (37 * (37 * (37 * (17 + "sbt.io.CopyOptions".##) + overwrite.##) + preserveLastModified.##) + preserveExecutable.##) + hardLink.##)
   }
   override def toString: String = {
-    "CopyOptions(" + overwrite + ", " + preserveLastModified + ", " + preserveExecutable + ")"
+    "CopyOptions(" + overwrite + ", " + preserveLastModified + ", " + preserveExecutable + ", " + hardLink + ")"
   }
-  private[this] def copy(overwrite: Boolean = overwrite, preserveLastModified: Boolean = preserveLastModified, preserveExecutable: Boolean = preserveExecutable): CopyOptions = {
-    new CopyOptions(overwrite, preserveLastModified, preserveExecutable)
+  private[this] def copy(overwrite: Boolean = overwrite, preserveLastModified: Boolean = preserveLastModified, preserveExecutable: Boolean = preserveExecutable, hardLink: Boolean = hardLink): CopyOptions = {
+    new CopyOptions(overwrite, preserveLastModified, preserveExecutable, hardLink)
   }
   def withOverwrite(overwrite: Boolean): CopyOptions = {
     copy(overwrite = overwrite)
@@ -42,9 +45,13 @@ final class CopyOptions private (
   def withPreserveExecutable(preserveExecutable: Boolean): CopyOptions = {
     copy(preserveExecutable = preserveExecutable)
   }
+  def withHardLink(hardLink: Boolean): CopyOptions = {
+    copy(hardLink = hardLink)
+  }
 }
 object CopyOptions {
   
   def apply(): CopyOptions = new CopyOptions()
   def apply(overwrite: Boolean, preserveLastModified: Boolean, preserveExecutable: Boolean): CopyOptions = new CopyOptions(overwrite, preserveLastModified, preserveExecutable)
+  def apply(overwrite: Boolean, preserveLastModified: Boolean, preserveExecutable: Boolean, hardLink: Boolean): CopyOptions = new CopyOptions(overwrite, preserveLastModified, preserveExecutable, hardLink)
 }

--- a/io/src/main/contraband/io.contra
+++ b/io/src/main/contraband/io.contra
@@ -16,4 +16,6 @@ type CopyOptions {
   ## If `true` the executable properties are copied.
   preserveExecutable: boolean! = true @since("0.0.1")
 
+  ## If 'true' the copy is a hardlink.
+  hardLink: boolean! = false @since("1.6.0")
 }

--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -823,6 +823,14 @@ object IO {
       options.hardLink
     )
 
+  // mima Compat
+  def copy(
+      sources: Traversable[(File, File)],
+      overwrite: Boolean,
+      preserveLastModified: Boolean,
+      preserveExecutable: Boolean,
+  ): Set[File] = copy(sources, overwrite, preserveLastModified, preserveExecutable, false)
+
   def copy(
       sources: Traversable[(File, File)],
       overwrite: Boolean,
@@ -871,13 +879,23 @@ object IO {
       options.preserveExecutable
     )
 
+  // mima Compat
   def copyDirectory(
       source: File,
       target: File,
       overwrite: Boolean = false,
       preserveLastModified: Boolean = false,
       preserveExecutable: Boolean = true,
-      hardLink: Boolean = false,
+  ): Unit =
+    copyDirectory(source, target, overwrite, preserveLastModified, preserveExecutable, false)
+
+  def copyDirectory(
+      source: File,
+      target: File,
+      overwrite: Boolean,
+      preserveLastModified: Boolean,
+      preserveExecutable: Boolean,
+      hardLink: Boolean,
   ): Unit = {
     val sources = PathFinder(source).allPaths pair Path.rebase(source, target)
     copy(sources, overwrite, preserveLastModified, preserveExecutable, hardLink)
@@ -901,12 +919,20 @@ object IO {
       options.hardLink
     )
 
+  // mima Compat
   def copyFile(
       sourceFile: File,
       targetFile: File,
       preserveLastModified: Boolean = false,
       preserveExecutable: Boolean = true,
-      hardLink: Boolean = false,
+  ): Unit = copyFile(sourceFile, targetFile, preserveLastModified, preserveExecutable, false)
+
+  def copyFile(
+      sourceFile: File,
+      targetFile: File,
+      preserveLastModified: Boolean,
+      preserveExecutable: Boolean,
+      hardLink: Boolean,
   ): Unit = {
     // NOTE: when modifying this code, test with larger values of CopySpec.MaxFileSizeBits than default
 

--- a/io/src/test/scala/sbt/io/IOSpec.scala
+++ b/io/src/test/scala/sbt/io/IOSpec.scala
@@ -83,6 +83,34 @@ class IOSpec extends FunSuite {
     }
   }
 
+  test("it should copy directories with hardlinks") {
+    IO.withTemporaryDirectory { dir =>
+      val subdir1 = new File(dir, "subdir1")
+      val nestedSubdir1 = new File(subdir1, "nested")
+      val subdir1File = new File(nestedSubdir1, "file")
+      IO.createDirectory(nestedSubdir1)
+      IO.write(subdir1File, "foo-1")
+      val subdir2 = new File(dir, "subdir2")
+      val nestedSubdir2 = new File(subdir2, "nested")
+      val subdir2File = new File(nestedSubdir2, "file")
+      IO.createDirectory(nestedSubdir2)
+      IO.write(subdir2File, "foo-2")
+
+      val copied = new File(dir, "copy")
+      val copiedNested = new File(copied, "nested")
+      val copiedFile = new File(copiedNested, "file")
+
+      val optionsWithHardLink = CopyOptions().withHardLink(true)
+      IO.copyDirectory(subdir1, copied, optionsWithHardLink)
+      assert(PathFinder(copied).allPaths.get().toSet == Set(copied, copiedNested, copiedFile))
+      assert(IO.read(copiedFile) == "foo-1")
+      IO.delete(copied)
+      IO.copyDirectory(subdir2, copied, optionsWithHardLink)
+      assert(PathFinder(copied).allPaths.get().toSet == Set(copied, copiedNested, copiedFile))
+      assert(IO.read(copiedFile) == "foo-2")
+    }
+  }
+
   test("toURI should make URI") {
     val u = IO.toURI(file("/etc/hosts"))
     assert(u.toString == "file:///etc/hosts")


### PR DESCRIPTION
This is interesting to "copy" files from a cache location to another working directory, without making actual IO copies of the files.  The [java API Files.createLink](https://docs.oracle.com/javase/7/docs/api/java/nio/file/Files.html#createLink(java.nio.file.Path,%20java.nio.file.Path)) uses a hardlink (rather than a symbolic link) to do this.  It also seems to be supported on Windows, so that's the extra plus.  Creating links for a directory are discouraged, so this does it as the individual file level.