### PR TITLE
fix IOSpecification on JDK 13+

### DIFF
--- a/io/src/test/scala/sbt/io/IOSpecification.scala
+++ b/io/src/test/scala/sbt/io/IOSpecification.scala
@@ -20,7 +20,7 @@ object IOSpecification extends Properties("IO") {
       Try(IO.classLocationPath(c)).toOption.exists {
         case jar if jar.getFileName.toString.endsWith(".jar") =>
           Files.isRegularFile(jar)
-        case jrt if jrt.toUri.getScheme == "jrt" =>
+        case jrt if jrt.getFileSystem.provider.getScheme == "jrt" =>
           jrt.toString.contains("/java.base")
         case dir =>
           Files.isDirectory(dir)


### PR DESCRIPTION
- fix https://github.com/sbt/io/issues/288

```
Welcome to Scala 2.13.7 (Java HotSpot(TM) 64-Bit Server VM, Java 17).
Type in expressions for evaluation. Or try :help.

scala> java.nio.file.FileSystems.getFileSystem(new java.net.URI("jrt:/")).getPath("java.base").getFileSystem.provider.getScheme
val res0: String = jrt

scala> java.nio.file.FileSystems.getFileSystem(new java.net.URI("jrt:/")).getPath("java.base").toUri
java.io.IOError: java.lang.RuntimeException: /java.base cannot be represented as URI
  at java.base/jdk.internal.jrtfs.JrtPath.toUri(JrtPath.java:175)
  ... 32 elided
Caused by: java.lang.RuntimeException: /java.base cannot be represented as URI
  ... 33 more
```