### PR TITLE
fix `Auto-application` warnings in Scala 2.13

### DIFF
--- a/io/src/main/scala/sbt/internal/io/SourceModificationWatch.scala
+++ b/io/src/main/scala/sbt/internal/io/SourceModificationWatch.scala
@@ -115,7 +115,7 @@ private[sbt] final class WatchState private (
 
   /** Retrieve events from the `WatchService` */
   private[sbt] def pollEvents(): Iterable[(Path, WatchEvent[_])] = {
-    val events = service.pollEvents
+    val events = service.pollEvents()
     events.toIterable.flatMap {
       case (k, evs) => evs.map((k.watchable().asInstanceOf[Path], _))
     }

--- a/io/src/main/scala/sbt/internal/nio/FileTreeRepositoryImpl.scala
+++ b/io/src/main/scala/sbt/internal/nio/FileTreeRepositoryImpl.scala
@@ -105,7 +105,7 @@ private[sbt] class FileTreeRepositoryImpl[T] extends FileTreeRepository[FileAttr
           case _                                   =>
         }
       }
-    res.result
+    res.result()
   }
   override def register(glob: Glob): Either[IOException, Observable[FileEvent[FileAttributes]]] = {
     throwIfClosed("register")

--- a/io/src/main/scala/sbt/nio/file/Glob.scala
+++ b/io/src/main/scala/sbt/nio/file/Glob.scala
@@ -549,7 +549,7 @@ object Glob {
                       stringBuilder.append(separator).append(c)
                     case c =>
                       components.add(stringBuilder.toString)
-                      stringBuilder.clear
+                      stringBuilder.clear()
                       stringBuilder.append(c)
                   }
                   fillComponents(nextIndex + 1)
@@ -559,7 +559,7 @@ object Glob {
                 }
               case '/' =>
                 components.add(stringBuilder.toString)
-                stringBuilder.clear
+                stringBuilder.clear()
                 fillComponents(i + 1)
               case c =>
                 stringBuilder.append(c)
@@ -810,7 +810,7 @@ object RelativeGlob {
         val leftIt = left.iterator
         val rightIt = right.iterator
         while (leftIt.hasNext && rightIt.hasNext) {
-          val res = ordering.compare(leftIt.next, rightIt.next)
+          val res = ordering.compare(leftIt.next(), rightIt.next())
           if (res != 0) return res
         }
         Ordering.Boolean.compare(leftIt.hasNext, rightIt.hasNext)

--- a/io/src/test/scala/sbt/io/PathFinderSpec.scala
+++ b/io/src/test/scala/sbt/io/PathFinderSpec.scala
@@ -40,7 +40,7 @@ trait PathFinderSpec extends FlatSpec with Matchers {
     val foo = Files.createTempFile(dir.toPath, "foo", "").toFile
     Files.createTempFile(dir.toPath, "bar", "").toFile
     val include = new SimpleFilter(_.startsWith("foo"))
-    PathFinder(dir).descendantsExcept(include, NothingFilter).get shouldBe Seq(foo)
+    PathFinder(dir).descendantsExcept(include, NothingFilter).get() shouldBe Seq(foo)
   }
   it should "apply exclude filter" in IO.withTemporaryDirectory { dir =>
     val excludeDir = Files.createDirectories(dir.toPath.resolve("sbt-0.13"))
@@ -57,8 +57,12 @@ trait PathFinderSpec extends FlatSpec with Matchers {
     val dirPath = dir.toPath
     val subdir = Files.createDirectories(dirPath.resolve("subdir")).toFile
     val file = Files.createFile(dirPath.resolve("file")).toFile
-    PathFinder(dir).descendantsExcept("*", "*sub*").get.toSet shouldBe Set(dir, file)
-    PathFinder(dir).descendantsExcept("*", NothingFilter).get.toSet shouldBe Set(dir, file, subdir)
+    PathFinder(dir).descendantsExcept("*", "*sub*").get().toSet shouldBe Set(dir, file)
+    PathFinder(dir).descendantsExcept("*", NothingFilter).get().toSet shouldBe Set(
+      dir,
+      file,
+      subdir
+    )
   }
   it should "work for complex extension filters" in IO.withTemporaryDirectory { dir =>
     val subdir = Files.createDirectories(dir.toPath.resolve("subdir"))

--- a/io/src/test/scala/sbt/nio/PathFilterSpec.scala
+++ b/io/src/test/scala/sbt/nio/PathFilterSpec.scala
@@ -129,7 +129,7 @@ class PathFilterSpec extends FlatSpec {
   they should "negate" in IO.withTemporaryDirectory { dir =>
     val dirPath = dir.toPath
     val foo = Files.createFile(dirPath / "foo.txt")
-    val hidden = Files.createFile(dirPath / ".hidden").setHidden
+    val hidden = Files.createFile(dirPath / ".hidden").setHidden()
     val filter = IsDirectory && !IsHidden
     val notFilter = !filter
     assert(notFilter == (!IsDirectory || IsHidden))


### PR DESCRIPTION
```
[warn] /home/runner/work/io/io/io/src/main/scala/sbt/internal/io/SourceModificationWatch.scala:118:26: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method pollEvents,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn]     val events = service.pollEvents
[warn]                          ^
[warn] /home/runner/work/io/io/io/src/main/scala/sbt/internal/nio/FileTreeRepositoryImpl.scala:108:9: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method result,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn]     res.result
[warn]         ^
[warn] /home/runner/work/io/io/io/src/main/scala/sbt/nio/file/Glob.scala:552:37: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method clear,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn]                       stringBuilder.clear
[warn]                                     ^
[warn] /home/runner/work/io/io/io/src/main/scala/sbt/nio/file/Glob.scala:562:31: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method clear,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn]                 stringBuilder.clear
[warn]                               ^
[warn] /home/runner/work/io/io/io/src/main/scala/sbt/nio/file/Glob.scala:813:45: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method next,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn]           val res = ordering.compare(leftIt.next, rightIt.next)
[warn]                                             ^
[warn] /home/runner/work/io/io/io/src/main/scala/sbt/nio/file/Glob.scala:813:59: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method next,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn]           val res = ordering.compare(leftIt.next, rightIt.next)
[warn]                                                           ^
```