### PR TITLE
use string interpolation instead of `+` method in `Char`

### DIFF
--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -1177,7 +1177,7 @@ object IO {
   /** Converts the given File to a URI.  If the File is relative, the URI is relative, unlike File.toURI*/
   def toURI(f: File): URI = {
     def ensureHeadSlash(name: String) =
-      if (name.nonEmpty && name.head != File.separatorChar) File.separatorChar + name
+      if (name.nonEmpty && name.head != File.separatorChar) s"${File.separatorChar}$name"
       else name
 
     val p = f.getPath


### PR DESCRIPTION
fix warning in Scala 2.13

> [warn] /home/runner/work/io/io/io/src/main/scala/sbt/io/IO.scala:1180:80: method + in class Char is deprecated (since 2.13.0): Adding a number and a String is deprecated. Use the string interpolation `s"$num$str"`
> [warn]       if (name.nonEmpty && name.head != File.separatorChar) File.separatorChar + name
> [warn]                                                                                ^
