### PR TITLE
Bump swoval version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,5 +16,5 @@ object Dependencies {
   val jnaVersion = "5.12.0"
   val jna = "net.java.dev.jna" % "jna" % jnaVersion
   val jnaPlatform = "net.java.dev.jna" % "jna-platform" % jnaVersion
-  val swovalFiles = "com.swoval" % "file-tree-views" % "2.1.9"
+  val swovalFiles = "com.swoval" % "file-tree-views" % "2.1.10"
 }


### PR DESCRIPTION
A metals user identified what appeared to be a performance regression introduced in v2.1.8 (https://github.com/swoval/swoval/issues/161). The new version, 2.1.10, attempts to restore the previous performance.