### PR TITLE
Add JDK 17 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
           - os: ubuntu-latest
             java: 11
             jobtype: 2
+          - os: ubuntu-latest
+            java: 17
+            jobtype: 2
           - os: macos-latest
             java: 8
             jobtype: 2


### PR DESCRIPTION
Self explanatory. I only added it to the Linux CI since it seems that we are only testing multiple JDK's on Linux (probably to reduce CI queues). Can only improve this in a later PR