### PR TITLE
Bump swoval to v2.1.12

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,5 +16,5 @@ object Dependencies {
   val jnaVersion = "5.13.0"
   val jna = "net.java.dev.jna" % "jna" % jnaVersion
   val jnaPlatform = "net.java.dev.jna" % "jna-platform" % jnaVersion
-  val swovalFiles = "com.swoval" % "file-tree-views" % "2.1.10"
+  val swovalFiles = "com.swoval" % "file-tree-views" % "2.1.12"
 }


### PR DESCRIPTION
For somewhat unknown reasons the native directory lister was very slow on windows for repos with deeply nested directory trees. This new version of swoval defaults to nio apis for Windows while retaining the native listers on posix platforms (where as far as I know there are no performance issues).

See https://github.com/swoval/swoval/issues/161.