### PR TITLE
fix warning. make MacJNA.TimeBuf final

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,6 +106,7 @@ val io = (project in file("io"))
         ) map (version => organization.value %% moduleName.value % version)
     }),
     mimaBinaryIssueFilters ++= Seq(
+      exclude[FinalClassProblem]("sbt.internal.io.MacJNA$TimeBuf"),
       // MiMa doesn't treat effectively final members as final
       // WORKAROUND typesafehub/migration-manager#162
       exclude[FinalMethodProblem]("sbt.io.SimpleFilter.accept"),

--- a/io/src/main/java/sbt/internal/io/MacJNA.java
+++ b/io/src/main/java/sbt/internal/io/MacJNA.java
@@ -45,7 +45,7 @@ public class MacJNA {
     };
   }
 
-  public static class TimeBuf extends Structure {
+  public static final class TimeBuf extends Structure {
     public int size;
     public long tv_sec;
     public long tv_nsec;


### PR DESCRIPTION
fix JDK 21 warning

- https://bugs.openjdk.org/browse/JDK-8299995


```
[warn] /my-sbt-io-project-path/io/src/main/java/sbt/internal/io/MacJNA.java:59:1: possible 'this' escape before subclass is fully initialized
[warn] setAlignType(Structure.ALIGN_NONE)
```