### PR TITLE
add `case` in for comprehension. prepare Scala 3.4

### DIFF
--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -558,7 +558,7 @@ object IO {
       isEmpty.getOrElseUpdate(f, dirs(f) && f.isDirectory && (f.listFiles forall visit))
 
     dirs foreach visit
-    for ((f, true) <- isEmpty) f.delete
+    for (case (f, true) <- isEmpty) f.delete
   }
 
   /** Deletes each file or directory (recursively) in `files`. */


### PR DESCRIPTION
- https://github.com/lampepfl/dotty/pull/18842

```
Welcome to Scala 3.4.0-RC1 (1.8.0_392, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                             
scala> for((f, true) <- List.empty[(Int, Boolean)]) yield f
-- Error: ----------------------------------------------------------------------
1 |for((f, true) <- List.empty[(Int, Boolean)]) yield f
  |        ^^^^
  |pattern's type (true : Boolean) is more specialized than the right hand side expression's type Boolean
  |
  |If the narrowing is intentional, this can be communicated by adding the `case` keyword before the full pattern,
  |which will result in a filtering for expression (using `withFilter`).
1 error found
```

```
Welcome to Scala 3.3.1 (1.8.0_392, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                             
scala> for((f, true) <- List.empty[(Int, Boolean)]) yield f
1 warning found
-- Warning: --------------------------------------------------------------------
1 |for((f, true) <- List.empty[(Int, Boolean)]) yield f
  |        ^^^^
  |pattern's type (true : Boolean) is more specialized than the right hand side expression's type Boolean
  |
  |If the narrowing is intentional, this can be communicated by adding the `case` keyword before the full pattern,
  |which will result in a filtering for expression (using `withFilter`).
val res0: List[Int] = List()
```