### PR TITLE
prepare JDK 23

### DIFF
--- a/io/src/main/scala/sbt/io/Using.scala
+++ b/io/src/main/scala/sbt/io/Using.scala
@@ -12,7 +12,20 @@
 package sbt
 package io
 
-import java.io._
+import java.io.{
+  BufferedInputStream,
+  BufferedOutputStream,
+  BufferedReader,
+  BufferedWriter,
+  File,
+  FileInputStream,
+  FileOutputStream,
+  IOException,
+  InputStream,
+  InputStreamReader,
+  OutputStream,
+  OutputStreamWriter,
+}
 import java.net.URL
 import java.nio.charset.Charset
 import java.util.jar.{ JarFile, JarInputStream, JarOutputStream }


### PR DESCRIPTION
- https://bugs.openjdk.org/browse/JDK-8305457

```
io/src/main/scala/sbt/io/Using.scala:15:8: This wildcard import imports java.io.IO, which is shadowed by sbt.io.IO.
[error] This is not according to the language specification and has changed in Scala 2.13, where java.io.IO takes precedence.
[error] To keep the same meaning in 2.12 and 2.13, un-import IO by adding `IO => _` to the import list.
[error] import java.io._
[error]        ^
[error] one error found
[error] (io / Compile / compileIncremental) Compilation failed
```