### PR TITLE
Fix normalized URI generation for UNC path

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ ThisBuild / version := {
   (sys.env.get("BUILD_VERSION") orElse sys.props.get("sbt.build.version")) match {
     case Some(v) => v
     case _ =>
-      if ((ThisBuild / isSnapshot).value) "1.6.0-SNAPSHOT"
+      if ((ThisBuild / isSnapshot).value) "1.10.2-SNAPSHOT"
       else old
   }
 }

--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -1160,7 +1160,7 @@ object IO {
    */
   def directoryURI(dir: File): URI = {
     assertAbsolute(dir)
-    directoryURI(dir.toURI.normalize)
+    directoryURI(dir.toPath.normalize.toUri)
   }
 
   /**
@@ -1177,7 +1177,7 @@ object IO {
       else
         new URI(str + "/")
 
-    dirURI.normalize
+    new File(dirURI).toPath.normalize.toUri
   }
 
   private[sbt] val isWindows: Boolean =

--- a/io/src/main/scala/sbt/io/Path.scala
+++ b/io/src/main/scala/sbt/io/Path.scala
@@ -292,7 +292,7 @@ object Path extends Mapper {
   def fileProperty(name: String): File = new File(System.getProperty(name))
   def userHome: File = fileProperty("user.home")
 
-  def absolute(file: File): File = new File(file.toURI.normalize).getAbsoluteFile
+  def absolute(file: File): File = new File(file.toPath.normalize.toUri).getAbsoluteFile
   def makeString(paths: Seq[File]): String = makeString(paths, File.pathSeparator)
   def makeString(paths: Seq[File], sep: String): String = {
     val separated = paths.map(_.getAbsolutePath)


### PR DESCRIPTION
### Issue

`IO.directoryURI` and `Path.absolute` both calls `toURI.normalize` to convert a `java.io.File` to a normalized URI, which [generates invalid URI for UNC path](https://bugs.openjdk.org/browse/JDK-4723726). As a result, sbt crashes when we try to open a project in a WSL directory.

Example: say we have a  `dir: java.io.File` representing `Ubuntu-24.04/home/jerrytan/testwsl/` in WSL, then calling `dir.toPath.toUri.normalize` yields `file:/wsl$/Ubuntu-24.04/home/jerrytan/testwsl/` , which then leads to

```
java.lang.RuntimeException: Invalid build URI (no handler available): file:/wsl$/OracleLinux_9/home/user/project/
        at scala.sys.package$.error(package.scala:30)
        at sbt.internal.Load$.$anonfun$builtinLoader$1(Load.scala:489)
        at sbt.internal.BuildLoader.$anonfun$apply$3(BuildLoader.scala:244)
        at scala.Option.getOrElse(Option.scala:189)
        at sbt.internal.BuildLoader.apply(BuildLoader.scala:244)
        at sbt.internal.Load$.loadURI$1(Load.scala:554)
        at sbt.internal.Load$.loadAll(Load.scala:570)
        at sbt.internal.Load$.loadURI(Load.scala:500)
        at sbt.internal.Load$.load(Load.scala:479)
```

### Fix

Call `toPath.normalize.toUri` instead. For above example, it yields `file:////wsl$/Ubuntu-24.04/home/jerrytan/testwsl/` which can be loaded by sbt. Note that the new file URL still do not follow the best practice as documented in Eugene's [blog post](https://eed3si9n.com/encoding-file-path-as-URI-reference/), but it indeed do not crash.

Closes https://github.com/sbt/sbt/issues/7135

Credit to reporter of https://github.com/sbt/sbt/issues/7135 for detailed investigation of the issue.