### PR TITLE
Configurable buffer size and flat compression for file entries for SBT

### DIFF
--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -46,7 +46,9 @@ object IO {
   val temporaryDirectory = new File(System.getProperty("java.io.tmpdir"))
 
   /** The size of the byte or char buffer used in various methods. */
-  private val BufferSize = 8192
+  private val BufferSize = Option(System.getProperty("sbt.io.buffer.size")).map(_.toInt).getOrElse(8192)
+
+  private val StoreFileEntry = Option(System.getProperty("sbt.io.zip.store")).exists(_.toBoolean)
 
   /** File scheme name */
   private[sbt] val FileScheme = "file"
@@ -711,6 +713,7 @@ object IO {
       //			log.debug("\tAdding " + file + " as " + name + " ...")
       val e = createEntry(name)
       e setTime time.getOrElse(getModifiedTimeOrZero(file))
+      if (StoreFileEntry) e setMethod ZipEntry.STORED
       e
     }
     def addFileEntry(file: File, name: String) = {

--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -46,9 +46,10 @@ object IO {
   val temporaryDirectory = new File(System.getProperty("java.io.tmpdir"))
 
   /** The size of the byte or char buffer used in various methods. */
-  private val BufferSize = Option(System.getProperty("sbt.io.buffer.size")).map(_.toInt).getOrElse(8192)
+  private val BufferSize =
+    Option(System.getProperty("sbt.io.buffer.size")).map(_.toInt).getOrElse(8192)
 
-  private val StoreFileEntry = Option(System.getProperty("sbt.io.zip.store")).exists(_.toBoolean)
+  private val DoNotCompressFiles = Option(System.getProperty("sbt.io.files.uncompressed")).exists(_.toBoolean)
 
   /** File scheme name */
   private[sbt] val FileScheme = "file"
@@ -713,7 +714,7 @@ object IO {
       //			log.debug("\tAdding " + file + " as " + name + " ...")
       val e = createEntry(name)
       e setTime time.getOrElse(getModifiedTimeOrZero(file))
-      if (StoreFileEntry) e setMethod ZipEntry.STORED
+      if (DoNotCompressFiles) e setMethod ZipEntry.STORED
       e
     }
     def addFileEntry(file: File, name: String) = {


### PR DESCRIPTION
We noticed that in CI pipelines running sbt, substantial part of the time and resources are spent to compress and uncompress the artefacts. 

This is very pronounced for the remote cache feature, which is a great way of sharing the stuff between several jobs in the same CI pipeline - however, actually storing and fetching artefacts is a heavy process.

It is aggravated by the fact that the CI pipelines usually are constrained by CPU and memory, and gzip compression is quite demanding on that. Our CI jobs could easily spend as much as half of the time pulling and pushing stuff from remote cache. 
As the storage is cheap, reduced artefact size doesn't really add much of the value.

The proposed minimal change doesn't alter existing behaviour by default, but adds a way to override file copy buffer size and disable compression for the file entries created by SBT.