### PR TITLE
Add Retry.io

### DIFF
--- a/io/src/main/scala/sbt/internal/io/Retry.scala
+++ b/io/src/main/scala/sbt/internal/io/Retry.scala
@@ -20,33 +20,100 @@ private[sbt] object Retry {
     try System.getProperty("sbt.io.retry.limit", defaultLimit.toString).toInt
     catch { case NonFatal(_) => defaultLimit }
   }
+  private final val defaultSleepInMillis = 100
+
+  /**
+   * Retry on all non-fatal exceptions that are NOT listed in
+   * the excludedExceptions list.
+   */
   private[sbt] def apply[@specialized T](f: => T, excludedExceptions: Class[? <: Throwable]*): T =
     apply(f, limit, excludedExceptions: _*)
+
+  /**
+   * Retry on all non-fatal exceptions that are NOT listed in
+   * the excludedExceptions list.
+   */
   private[sbt] def apply[@specialized T](
       f: => T,
       limit: Int,
       excludedExceptions: Class[? <: Throwable]*,
-  ): T = apply(f, limit, 100, excludedExceptions: _*)
+  ): T = apply(f, limit, defaultSleepInMillis, excludedExceptions: _*)
+
+  /**
+   * Retry on all non-fatal exceptions that are NOT listed in
+   * the excludedExceptions list.
+   */
   private[sbt] def apply[@specialized T](
       f: => T,
       limit: Int,
       sleepInMillis: Long,
       excludedExceptions: Class[? <: Throwable]*,
   ): T = {
-    require(limit >= 1, "limit must be 1 or higher: was: " + limit)
-    def filter(e: Throwable): Boolean = excludedExceptions match {
+    def allowRetry(e: Throwable): Boolean = excludedExceptions match {
       case s if s.nonEmpty =>
         !excludedExceptions.exists(_.isAssignableFrom(e.getClass))
       case _ =>
         true
     }
+    impl(limit = limit, sleepInMillis = sleepInMillis)(allowRetry)(f)
+  }
+
+  /**
+   * Retry on all IOExceptions that are NOT listed in
+   * the excludedExceptions list.
+   * Non-IOException will immediately throw.
+   */
+  private[sbt] def io[@specialized A1](f: => A1, excludedExceptions: Class[? <: IOException]*): A1 =
+    io(f, limit, excludedExceptions: _*)
+
+  /**
+   * Retry on all IOExceptions that are NOT listed in
+   * the excludedExceptions list.
+   * Non-IOException will immediately throw.
+   */
+  private[sbt] def io[@specialized A1](
+      f: => A1,
+      limit: Int,
+      excludedExceptions: Class[? <: IOException]*,
+  ): A1 = io(f, limit, defaultSleepInMillis, excludedExceptions: _*)
+
+  /**
+   * Retry on all IOExceptions that are NOT listed in
+   * the excludedExceptions list.
+   * Non-IOException will immediately throw.
+   */
+  private[sbt] def io[@specialized A1](
+      f: => A1,
+      limit: Int,
+      sleepInMillis: Long,
+      excludedExceptions: Class[? <: IOException]*,
+  ): A1 = {
+    def allowRetry(e: Throwable): Boolean =
+      e match {
+        case ioe: IOException =>
+          excludedExceptions match {
+            case s if s.nonEmpty =>
+              !excludedExceptions.exists(_.isAssignableFrom(ioe.getClass))
+            case _ =>
+              true
+          }
+        case _ => false
+      }
+    impl(limit = limit, sleepInMillis = sleepInMillis)(allowRetry)(f)
+  }
+
+  private def impl[@specialized A1](
+      limit: Int,
+      sleepInMillis: Long,
+  )(allowRetry: Throwable => Boolean)(f: => A1): A1 = {
+    require(limit >= 1, "limit must be 1 or higher: was: " + limit)
     var attempt = 1
     var firstException: Throwable = null
     while (attempt <= limit) {
       try {
         return f
       } catch {
-        case NonFatal(e) if filter(e) =>
+        case NonFatal(e) if allowRetry(e) =>
           if (firstException == null) firstException = e
           // https://github.com/sbt/io/issues/295
           // On Windows, we're seeing java.nio.file.AccessDeniedException with sleep(0).

--- a/io/src/test/scala/sbt/internal/io/RetrySpec.scala
+++ b/io/src/test/scala/sbt/internal/io/RetrySpec.scala
@@ -20,7 +20,20 @@ object RetrySpec extends verify.BasicTestSuite {
     val i = new AtomicInteger()
     def throww(): Any = throw new IOException(i.incrementAndGet().toString)
     try {
-      Retry(throww(), limit = 10, sleepInMillis = 0, noExcluded: _*)
+      Retry(throww(), limit = 10, sleepInMillis = 10, noExcluded: _*)
+      assert(false)
+    } catch {
+      case ioe: IOException =>
+        assert(ioe.getMessage == "1")
+        assert(i.get() == 10)
+    }
+  }
+
+  test("Retry.io should throw first exception after number of failures") {
+    val i = new AtomicInteger()
+    def throww(): Any = throw new IOException(i.incrementAndGet().toString)
+    try {
+      Retry.io(throww(), limit = 10, sleepInMillis = 10, noExcluded: _*)
       assert(false)
     } catch {
       case ioe: IOException =>
@@ -52,5 +65,13 @@ object RetrySpec extends verify.BasicTestSuite {
       else ???
     Retry(throww())
     ()
+  }
+
+  test("Retry.io should throw non-IOException") {
+    def throww(): Any = ???
+    intercept[NotImplementedError] {
+      Retry.io(throww())
+      ()
+    }
   }
 }


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/8058

## Problem
I expanded Retry(...) to retry non-IOExceptions, which broke compile task.

## Solution
This adds back the older behavior under Retry.io(...).