### PR TITLE
Small documentation fix to `RegularFileFilter`

### DIFF
--- a/io/src/main/scala/sbt/io/NameFilter.scala
+++ b/io/src/main/scala/sbt/io/NameFilter.scala
@@ -223,7 +223,7 @@ case object DirectoryFilter extends FileFilter with PathFilter {
   override def accept(path: NioPath, attributes: FileAttributes): Boolean = attributes.isDirectory
 }
 
-/** A [[FileFilter]] that selects files that are a directory according to `java.io.File.isFile`. */
+/** A [[FileFilter]] that selects files that are a normal file according to `java.io.File.isFile`. */
 case object RegularFileFilter extends FileFilter with PathFilter {
   def accept(file: File): Boolean = file.isFile
   override def accept(path: NioPath, attributes: FileAttributes): Boolean = attributes.isRegularFile


### PR DESCRIPTION
Changed the documentation to say that the filter selects normal files instead of saying that the filter selects directories.