### PR TITLE
Use `-Werror` instead of `-Xfatal-warnings`

### DIFF
--- a/project/HouseRulesPluglin.scala
+++ b/project/HouseRulesPluglin.scala
@@ -15,7 +15,7 @@ object HouseRulesPlugin extends AutoPlugin {
     scalacOptions += "-language:higherKinds",
     scalacOptions += "-language:implicitConversions",
     scalacOptions ++= "-Xfuture".ifScala213OrMinus.value.toList,
-    scalacOptions ++= "-Xfatal-warnings"
+    scalacOptions ++= "-Werror"
       .ifScala(v => {
         sys.props.get("sbt.build.fatal") match {
           case Some(_) => java.lang.Boolean.getBoolean("sbt.build.fatal")


### PR DESCRIPTION
- https://github.com/scala/scala3/pull/24359

`-Xfatal-warnings` is deprecated since Scala 3.8

