### PR TITLE
Fix old varargs splice syntax

### DIFF
--- a/io/src/main/scala/sbt/io/NameFilter.scala
+++ b/io/src/main/scala/sbt/io/NameFilter.scala
@@ -138,37 +138,37 @@ final class ExtensionFilter(val extensions: String*) extends NameFilter {
 
   /** Constructs a filter that accepts a `File` if it matches either this filter or the given `filter`. */
   override def |(filter: NameFilter): NameFilter = filter match {
-    case that: ExtensionFilter => new ExtensionFilter(this.extensions ++ that.extensions: _*)
+    case that: ExtensionFilter => new ExtensionFilter((this.extensions ++ that.extensions)*)
     case _                     => super.|(filter)
   }
 
   /** Constructs a filter that accepts a `File` if it matches both this filter and the given `filter`. */
   override def &(filter: NameFilter): NameFilter = filter match {
-    case that: ExtensionFilter => new ExtensionFilter(this.extensions intersect that.extensions: _*)
+    case that: ExtensionFilter => new ExtensionFilter(this.extensions.intersect(that.extensions)*)
     case _                     => super.&(filter)
   }
 
   /** Constructs a filter that accepts a `File` if it matches this filter but does not match the given `filter`. */
   override def -(filter: NameFilter): NameFilter = filter match {
-    case that: ExtensionFilter => new ExtensionFilter(this.extensions diff that.extensions: _*)
+    case that: ExtensionFilter => new ExtensionFilter(this.extensions.diff(that.extensions)*)
     case _                     => super.-(filter)
   }
 
   /** Constructs a filter that accepts a `File` if it matches either this filter or the given `filter`. */
   override def ||(filter: FileFilter): FileFilter = filter match {
-    case that: ExtensionFilter => new ExtensionFilter(this.extensions ++ that.extensions: _*)
+    case that: ExtensionFilter => new ExtensionFilter((this.extensions ++ that.extensions)*)
     case _                     => super.||(filter)
   }
 
   /** Constructs a filter that accepts a `File` if it matches both this filter and the given `filter`. */
   override def &&(filter: FileFilter): FileFilter = filter match {
-    case that: ExtensionFilter => new ExtensionFilter(this.extensions intersect that.extensions: _*)
+    case that: ExtensionFilter => new ExtensionFilter(this.extensions.intersect(that.extensions)*)
     case _                     => super.&&(filter)
   }
 
   /** Constructs a filter that accepts a `File` if it matches this filter but does not match the given `filter`. */
   override def --(filter: FileFilter): FileFilter = filter match {
-    case that: ExtensionFilter => new ExtensionFilter(this.extensions diff that.extensions: _*)
+    case that: ExtensionFilter => new ExtensionFilter(this.extensions.diff(that.extensions)*)
     case _                     => super.--(filter)
   }
   override def toString: String = s"ExtensionFilter(${extensions mkString ","})"


### PR DESCRIPTION
https://docs.scala-lang.org/scala3/reference/changed-features/vararg-splices.html


```
[warn] -- Warning: /home/runner/work/io/io/io/src/main/scala/sbt/io/NameFilter.scala:141:90 
[warn] 141 |    case that: ExtensionFilter => new ExtensionFilter(this.extensions ++ that.extensions: _*)
[warn]     |                                                                                          ^
[warn]     |The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead
[warn]     |This construct can be rewritten automatically under -rewrite -source 3.4-migration.
[warn] -- Warning: /home/runner/work/io/io/io/src/main/scala/sbt/io/NameFilter.scala:147:97 
[warn] 147 |    case that: ExtensionFilter => new ExtensionFilter(this.extensions intersect that.extensions: _*)
[warn]     |                                                                                                 ^
[warn]     |The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead
[warn]     |This construct can be rewritten automatically under -rewrite -source 3.4-migration.
[warn] -- Warning: /home/runner/work/io/io/io/src/main/scala/sbt/io/NameFilter.scala:153:92 
[warn] 153 |    case that: ExtensionFilter => new ExtensionFilter(this.extensions diff that.extensions: _*)
[warn]     |                                                                                            ^
[warn]     |The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead
[warn]     |This construct can be rewritten automatically under -rewrite -source 3.4-migration.
[warn] -- Warning: /home/runner/work/io/io/io/src/main/scala/sbt/io/NameFilter.scala:159:90 
[warn] 159 |    case that: ExtensionFilter => new ExtensionFilter(this.extensions ++ that.extensions: _*)
[warn]     |                                                                                          ^
[warn]     |The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead
[warn]     |This construct can be rewritten automatically under -rewrite -source 3.4-migration.
[warn] -- Warning: /home/runner/work/io/io/io/src/main/scala/sbt/io/NameFilter.scala:165:97 
[warn] 165 |    case that: ExtensionFilter => new ExtensionFilter(this.extensions intersect that.extensions: _*)
[warn]     |                                                                                                 ^
[warn]     |The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead
[warn]     |This construct can be rewritten automatically under -rewrite -source 3.4-migration.
[warn] -- Warning: /home/runner/work/io/io/io/src/main/scala/sbt/io/NameFilter.scala:171:92 
[warn] 171 |    case that: ExtensionFilter => new ExtensionFilter(this.extensions diff that.extensions: _*)
[warn]     |                                                                                            ^
[warn]     |The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead
[warn]     |This construct can be rewritten automatically under -rewrite -source 3.4-migration.
```