### PR TITLE
Fix eta-expansion warnings

### DIFF
--- a/io/src/test/scala/sbt/io/FileUtilitiesSpecification.scala
+++ b/io/src/test/scala/sbt/io/FileUtilitiesSpecification.scala
@@ -18,12 +18,12 @@ import scala.reflect.ClassTag
 object WriteContentSpecification extends Properties("Write content") {
   sys.props.put("jna.nosys", "true")
 
-  property("Round trip string") = forAll(writeAndCheckString _)
-  property("Round trip bytes") = forAll(writeAndCheckBytes _)
-  property("Write string overwrites") = forAll(overwriteAndCheckStrings _)
-  property("Write bytes overwrites") = forAll(overwriteAndCheckBytes _)
-  property("Append string appends") = forAll(appendAndCheckStrings _)
-  property("Append bytes appends") = forAll(appendAndCheckBytes _)
+  property("Round trip string") = forAll(writeAndCheckString)
+  property("Round trip bytes") = forAll(writeAndCheckBytes)
+  property("Write string overwrites") = forAll(overwriteAndCheckStrings)
+  property("Write bytes overwrites") = forAll(overwriteAndCheckBytes)
+  property("Append string appends") = forAll(appendAndCheckStrings)
+  property("Append bytes appends") = forAll(appendAndCheckBytes)
   property("Unzip doesn't stack overflow") = largeUnzip()
   property("Unzip errors given parent traversal") = testZipSlip()
 

--- a/io/src/test/scala/sbt/io/StashSpec.scala
+++ b/io/src/test/scala/sbt/io/StashSpec.scala
@@ -54,7 +54,7 @@ class StashSpec extends AnyFlatSpec with Matchers {
       case _: TestError | _: TestException | _: TestRuntimeException => false
     }
 
-  def allCorrect(s: Seq[File]): Unit = (s.toList zip TestFiles.toList).foreach((correct _).tupled)
+  def allCorrect(s: Seq[File]): Unit = (s.toList zip TestFiles.toList).foreach(correct.tupled)
 
   def correct(check: File, ref: (File, String)): Unit = {
     assert(check.exists)


### PR DESCRIPTION
https://docs.scala-lang.org/scala3/book/fun-eta-expansion.html

```
[warn] -- Warning: /home/runner/work/io/io/io/src/test/scala/sbt/io/FileUtilitiesSpecification.scala:21:61 
[warn] 21 |  property("Round trip string") = forAll(writeAndCheckString _)
[warn]    |                                         ^^^^^^^^^^^^^^^^^^^^^
[warn]    |The syntax `<function> _` is no longer supported;
[warn]    |you can simply leave out the trailing ` _`
[warn]    |This construct can be rewritten automatically under -rewrite -source 3.4-migration.
[warn] -- Warning: /home/runner/work/io/io/io/src/test/scala/sbt/io/FileUtilitiesSpecification.scala:22:59 
[warn] 22 |  property("Round trip bytes") = forAll(writeAndCheckBytes _)
[warn]    |                                        ^^^^^^^^^^^^^^^^^^^^
[warn]    |The syntax `<function> _` is no longer supported;
[warn]    |you can simply leave out the trailing ` _`
[warn]    |This construct can be rewritten automatically under -rewrite -source 3.4-migration.
```