### PR TITLE
Fix copyArrayToImmutableIndexedSeq warning

### DIFF
--- a/io/src/main/scala/sbt/io/NameFilter.scala
+++ b/io/src/main/scala/sbt/io/NameFilter.scala
@@ -16,6 +16,7 @@ import java.nio.file.{ Files, Path => NioPath }
 import java.util.regex.Pattern
 
 import sbt.nio.file.{ FileAttributes, PathFilter }
+import scala.collection.immutable.ArraySeq
 
 /** A `java.io.FileFilter` with additional methods for combining filters. */
 trait FileFilter extends java.io.FileFilter {
@@ -386,7 +387,11 @@ object GlobFilter {
           new ExtensionFilter(ext.drop(1))
         case Array(prefix, "") => new PrefixFilter(prefix)
         case Array("", suffix) => new SuffixFilter(suffix)
-        case _ => new PatternFilter(parts, Pattern.compile(parts.map(quote).mkString(".*")))
+        case _                 =>
+          new PatternFilter(
+            ArraySeq.unsafeWrapArray(parts),
+            Pattern.compile(parts.map(quote).mkString(".*"))
+          )
       }
     }
   }


### PR DESCRIPTION
```
[warn] -- Deprecation Warning: /home/runner/work/io/io/io/src/main/scala/sbt/io/NameFilter.scala:389:36 
[warn] 389 |        case _ => new PatternFilter(parts, Pattern.compile(parts.map(quote).mkString(".*")))
[warn]     |                                    ^
[warn]     |method copyArrayToImmutableIndexedSeq in class LowPriorityImplicits2 is deprecated since 2.13.0: implicit conversions from Array to immutable.IndexedSeq are implemented by copying; use `toIndexedSeq` explicitly if you want to copy, or use the more efficient non-copying ArraySeq.unsafeWrapArray
```