### PR TITLE
Use filterInPlace instead of retain

### DIFF
--- a/io/src/main/scala/sbt/internal/nio/FileEventMonitor.scala
+++ b/io/src/main/scala/sbt/internal/nio/FileEventMonitor.scala
@@ -304,7 +304,7 @@ private[sbt] object FileEventMonitor {
       // thread polling the events. Because the period between polls could be quite large, it's
       // possible that there are unhandled events that actually occurred within the anti-entropy
       // window for the path. By setting a long retention time, we try to avoid this.
-      antiEntropyDeadlines.retain((_, deadline) => Deadline.now < deadline + retentionPeriod)
+      antiEntropyDeadlines.filterInPlace((_, deadline) => Deadline.now < deadline + retentionPeriod)
       transformed match {
         case s: Seq[FileEvent[T]] if s.nonEmpty => s
         case _                                  =>


### PR DESCRIPTION
```
[warn] -- Deprecation Warning: /home/runner/work/io/io/io/src/main/scala/sbt/internal/nio/FileEventMonitor.scala:307:27 
[warn] 307 |      antiEntropyDeadlines.retain((_, deadline) => Deadline.now < deadline + retentionPeriod)
[warn]     |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[warn]     |method retain in trait MapOps is deprecated since 2.13.0: Use filterInPlace instead
```

https://github.com/scala/scala3/blob/b5d15acdc4c6749a86eb32eb211e0ae08e7c20ce/library/src/scala/collection/mutable/Map.scala#L169-L170