### PR TITLE
Fix warning. use compiletime.uninitialized

### DIFF
--- a/io/src/main/scala/sbt/internal/io/DeferredWriter.scala
+++ b/io/src/main/scala/sbt/internal/io/DeferredWriter.scala
@@ -16,7 +16,7 @@ import java.io.Writer
 /** A `Writer` that avoids constructing the underlying `Writer` with `make` until a method other than `close` is called on this `Writer`. */
 private[sbt] final class DeferredWriter(make: => Writer) extends Writer {
   private var opened = false
-  private var delegate0: Writer = _
+  private var delegate0: Writer = compiletime.uninitialized
   private def delegate: Writer = synchronized {
     if (delegate0 eq null) {
       delegate0 = make


### PR DESCRIPTION
```
[warn] -- Warning: /home/runner/work/io/io/io/src/main/scala/sbt/internal/io/DeferredWriter.scala:19:34 
[warn] 19 |  private var delegate0: Writer = _
[warn]    |                                  ^
[warn]    |`= _` has been deprecated; use `= uninitialized` instead.
[warn]    |`uninitialized` can be imported with `scala.compiletime.uninitialized`.
[warn]    |This construct can be rewritten automatically under -rewrite -source 3.4-migration.
```