### PR TITLE
bport: fix ExtensionFilter.hashCode

### DIFF
--- a/io/src/main/scala/sbt/io/NameFilter.scala
+++ b/io/src/main/scala/sbt/io/NameFilter.scala
@@ -134,7 +134,7 @@ final class ExtensionFilter(val extensions: String*) extends NameFilter {
     case that: ExtensionFilter => this.set == that.set
     case _                     => false
   }
-  override lazy val hashCode: Int = extensions.hashCode
+  override lazy val hashCode: Int = set.hashCode
 
   /** Constructs a filter that accepts a `File` if it matches either this filter or the given `filter`. */
   override def |(filter: NameFilter): NameFilter = filter match {


### PR DESCRIPTION
This is a 1.12.x backport of https://github.com/sbt/io/pull/452