### PR TITLE
fix: Fixes file permissions

### DIFF
--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -16,7 +16,7 @@ import java.net.{ URI, URISyntaxException, URL }
 import java.nio.charset.Charset
 import java.nio.file.attribute.PosixFilePermissions
 import java.nio.file.{ Path => NioPath, _ }
-import java.util.{ Locale, Properties }
+import java.util.{ Locale, Properties, UUID }
 import java.util.jar.{ Attributes, JarEntry, JarFile, JarOutputStream, Manifest }
 import java.util.zip.{ CRC32, ZipEntry, ZipInputStream, ZipOutputStream }
 
@@ -470,22 +470,24 @@ object IO {
     val parent = Option(to.getAbsoluteFile.getParentFile).getOrElse(new File("."))
     createDirectory(parent)
     val name = to.getName
-    val prefix = if (name.length >= 3) name + "." else "sbt-" + name + "."
-    val staging = Files.createTempFile(parent.toPath, prefix, ".tmp")
+    val prefix = if (name.length >= 3) s"${name}." else s"sbt-${name}."
+    val u = UUID.randomUUID().toString().take(8)
+    val staging = new File(parent, s"${prefix}${u}.tmp").toPath()
+    touch(staging.toFile())
     try {
-      val result = write(staging.toFile)
+      val result = write(staging.toFile())
       try
         Retry(
           Files.move(
             staging,
-            to.toPath,
+            to.toPath(),
             StandardCopyOption.REPLACE_EXISTING,
             StandardCopyOption.ATOMIC_MOVE
           )
         )
       catch {
         case _: AtomicMoveNotSupportedException =>
-          Retry(Files.move(staging, to.toPath, StandardCopyOption.REPLACE_EXISTING))
+          Retry(Files.move(staging, to.toPath(), StandardCopyOption.REPLACE_EXISTING))
       }
       result
     } finally {

--- a/io/src/test/scala/sbt/io/IOSpecification.scala
+++ b/io/src/test/scala/sbt/io/IOSpecification.scala
@@ -58,10 +58,15 @@ object IOSpecification extends Properties("IO") {
     val target = new java.io.File(dir, "target.txt")
     try {
       IO.write(source, "complete")
-      IO.write(target, "previous")
+      val p1 =
+        if (IO.isWindows) None
+        else Some(Files.getPosixFilePermissions(source.toPath()))
       IO.copyFile(source, target)
+      val p2 =
+        if (IO.isWindows) None
+        else Some(Files.getPosixFilePermissions(target.toPath()))
       val content = IO.read(target)
-      content ?= "complete"
+      (content ?= "complete") && (p1 == p2)
     } finally IO.delete(dir)
   }
 


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/9340

## Problem
The use of Files.createTempFile seems to create narrower file permissions than before.

## Solution
Manually create a random file name, but use IO.touch.