### PR TITLE
Handling AccessDeniedException on project jar

### DIFF
--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -539,6 +539,10 @@ object IO {
       // Files.move with ATOMIC_MOVE possibly replaces and without has a race condition
       try retry(Files.createLink(toPath, staging)) // try this first
       catch {
+        case _: AccessDeniedException =>
+          transferAndClose(new FileInputStream(staging.toFile()), new FileOutputStream(to, false))
+          Files.deleteIfExists(staging)
+          ()
         case e @ (_: UnsupportedOperationException | _: IOException)
             if !e.isInstanceOf[FileAlreadyExistsException] =>
           move()


### PR DESCRIPTION
Part of the fix for [9651](https://github.com/sbt/sbt/issues/9651)

On Windows, Files.move with ATOMIC_MOVE can fail with AccessDeniedException when the target file is locked by another process (e.g., an sbt server or compiler holding a file handle). This causes intermittent build failures when writing jar files.

This change adds a catch clause for AccessDeniedException in [IO.writeFileAtomically()](vscode-webview://16530kufkd397s742d07t2qo7kbqfag08k8gt3r7cvrsbkdc0vrh/io/io/src/main/scala/sbt/io/IO.scala:478) that falls back to a stream copy via transferAndClose, followed by cleanup of the staging .tmp file.

Before: AccessDeniedException is retried 10 times by Retry (1 second of wasted retries), then propagates as a fatal error.

After: AccessDeniedException is caught after the Retry attempts exhaust, and the file is written via stream copy as a last resort.