### PR TITLE
fix: On Windows, create JAR or copy file in-situ

### DIFF
--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -1140,7 +1140,7 @@ object IO {
       !sourceFile.isDirectory,
       "Source file '" + sourceFile.getAbsolutePath + "' is a directory."
     )
-    writeFileAtomically(targetFile) { staging =>
+    writeFile(targetFile) { staging =>
       fileInputChannel(sourceFile) { in =>
         fileOutputChannel(staging) { out =>
           // maximum bytes per transfer according to  from http://dzone.com/snippets/java-filecopy-using-nio

--- a/io/src/main/scala/sbt/io/IO.scala
+++ b/io/src/main/scala/sbt/io/IO.scala
@@ -73,6 +73,9 @@ object IO {
 
   private lazy val jrtFs = FileSystems.getFileSystem(URI.create("jrt:/"))
 
+  private[sbt] val isWindows: Boolean =
+    System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("windows")
+
   /**
    * Returns the NIO Path to the directory, Java module, or the JAR file containing the class file `cl`.
    * If the location cannot be determined, an error is generated.
@@ -475,6 +478,11 @@ object IO {
         transfer(in, outputStream)
       }
     }
+
+  /** Helper function to write atomically on non-Windows. */
+  private[sbt] def writeFile[A1](to: File)(write: File => A1): A1 =
+    if (isWindows) write(to)
+    else writeFileAtomically(to, ownerOnly = false)(write)
 
   /**
    * Stages a write to a sibling temp file and atomically replaces `to` only after
@@ -884,7 +892,7 @@ object IO {
         case parentFile => parentFile
       }
       createDirectory(outputDir)
-      writeFileAtomically(outputFile) { staging =>
+      writeFile(outputFile) { staging =>
         withZipOutput(staging, manifest, localTime, deflateOn) { output =>
           val createEntry: (String => ZipEntry) =
             if (manifest.isDefined) new JarEntry(_) else new ZipEntry(_)
@@ -1407,9 +1415,6 @@ object IO {
 
     dirURI.normalize
   }
-
-  private[sbt] val isWindows: Boolean =
-    System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("windows")
 
   /** Converts the given File to a URI.  If the File is relative, the URI is relative, unlike File.toURI */
   def toURI(f: File): URI = {

--- a/io/src/test/scala/sbt/io/IOSpecification.scala
+++ b/io/src/test/scala/sbt/io/IOSpecification.scala
@@ -78,7 +78,7 @@ object IOSpecification extends Properties("IO") {
       IO.write(target, "previous")
       val failed = Try(IO.copyFile(source, target)).isFailure
       val content = IO.read(target)
-      (failed ?= true) && (content ?= "previous")
+      IO.isWindows || ((failed ?= true) && (content ?= "previous"))
     } finally IO.delete(dir)
   }
 

--- a/io/src/test/scala/sbt/io/IOSpecification.scala
+++ b/io/src/test/scala/sbt/io/IOSpecification.scala
@@ -94,7 +94,7 @@ object IOSpecification extends Properties("IO") {
         IO.jar(Seq(phantom -> "phantom.txt"), target, new java.util.jar.Manifest, None)
       ).isFailure
       val content = IO.read(target)
-      (failed ?= true) && (content ?= "previous")
+      IO.isWindows || ((failed ?= true) && (content ?= "previous"))
     } finally IO.delete(dir)
   }
 

--- a/io/src/test/scala/sbt/io/ZipSpec.scala
+++ b/io/src/test/scala/sbt/io/ZipSpec.scala
@@ -12,6 +12,7 @@
 package sbt.io
 
 import java.io.{ BufferedOutputStream, File, FileOutputStream }
+import java.net.URLClassLoader
 import java.nio.file.Files
 import java.util.concurrent.{ Executors, Future }
 import java.util.concurrent.atomic.AtomicInteger
@@ -156,6 +157,43 @@ class ZipSpec extends AnyFunSuite {
         assert(jf.getManifest.getMainAttributes.getValue(Attributes.Name.MAIN_CLASS) === "Main")
         assert(jf.getEntry("a.txt") != null)
       } finally jf.close()
+    }
+  }
+
+  test("IO.jar can overwrite a jar file a classloader still has open") {
+    // Windows repro for the AccessDeniedException seen when re-jarring a path that's
+    // still open elsewhere: the JDK's zip/jar file channel doesn't request
+    // FILE_SHARE_DELETE, so the rename `IO.jar`'s atomic write ends with can fail there
+    // even though nothing on this JVM still has the file open for writing.
+    IO.withTemporaryDirectory { tmp =>
+      val dir = tmp / "src"
+      IO.createDirectory(dir)
+      val jar = tmp / "out.jar"
+      val className = "AdHocFixture"
+
+      def buildJar(value: Int): Unit = {
+        val classFile = compileClass(
+          dir,
+          className,
+          s"public class $className { public static final int VALUE = $value; }"
+        )
+        IO.jar(Seq(classFile -> s"$className.class"), jar, new Manifest, fixedTime)
+      }
+
+      buildJar(1)
+
+      val loader = new URLClassLoader(Array(jar.toURI.toURL), null)
+      try {
+        val loaded = loader.loadClass(className)
+        assert(loaded.getField("VALUE").getInt(null) === 1)
+
+        // `jar` is still open for reading inside `loader` at this point.
+        buildJar(2)
+
+        val jf = new JarFile(jar)
+        try assert(jf.getJarEntry(s"$className.class") != null, "overwritten jar lost its entry")
+        finally jf.close()
+      } finally loader.close()
     }
   }
 
@@ -427,6 +465,18 @@ class ZipSpec extends AnyFunSuite {
   // -- helpers ---------------------------------------------------------------
 
   private def write(file: File, content: String): Unit = IO.write(file, content)
+
+  /** Compiles `source` (a single top level class named `className`) and returns its `.class` file. */
+  private def compileClass(dir: File, className: String, source: String): File = {
+    val javaFile = dir / s"$className.java"
+    write(javaFile, source)
+    val compiler = javax.tools.ToolProvider.getSystemJavaCompiler
+    assert(compiler != null, "no system Java compiler available to build the fixture class")
+    val result =
+      compiler.run(null, null, null, "-d", dir.getAbsolutePath, javaFile.getAbsolutePath)
+    assert(result == 0, s"failed to compile $className")
+    dir / s"$className.class"
+  }
 
   /**
    * Archives `build`'s files three ways and compares twice: `IO`'s writer against the reference,


### PR DESCRIPTION
Fixes https://github.com/sbt/io/issues/557

## Problem
There seems to be several call stacks where on Windows, the user gets an AccessDeniedException while performing a seemingly normal task. This is likely due to:
1. NTFS file system not allowing the JAR or zip files to be deleted while they are locked by another process, and 
2. Atomic writing (https://github.com/sbt/io/pull/505), which requires deletion of the original file

While preventing half-writing might be useful in some cases, in most cases the task engine itself should prevent the race conditions anyway. On Windows, we might want to back off from atomic writing with a few exceptions like writing text files.

- https://github.com/sbt/sbt/issues/9651
- https://github.com/sbt/sbt/issues/9724
- https://github.com/sbt/sbt/issues/9618

## Solution
1. Create JAR file in-situ
2. Copy files in-situ, and use `IO.copyFile` where possible
